### PR TITLE
Fix stripping of apis from the final .so

### DIFF
--- a/core/BUILD
+++ b/core/BUILD
@@ -15,7 +15,8 @@ cc_library(
         "//core/util/logging",
         "@libtorch//:libtorch",
         "@tensorrt//:nvinfer"
-    ]
+    ],
+    alwayslink=True, 
 )
 
 

--- a/cpp/api/BUILD
+++ b/cpp/api/BUILD
@@ -17,7 +17,8 @@ cc_library(
         "//core/util:prelude"
     ],
     strip_include_prefix = "include/",
-    linkstatic = True 
+    linkstatic = True,
+    alwayslink = True
 )
     
     


### PR DESCRIPTION
When the library is full built the actual apis were getting stripped. Use alwayslink for both the core top level and api level to make sure they make it into the final .so

Thanks @bddppq for the pointer