### PR TITLE
fix(aten::batch_norm): A new batch norm implementation that hopefully doesnt have the same performace cost

### DIFF
--- a/core/lowering/lowering.cpp
+++ b/core/lowering/lowering.cpp
@@ -27,6 +27,7 @@ void LowerGraph(std::shared_ptr<torch::jit::Graph>& g) {
     passes::FuseFlattenLinear(g);
     passes::Conv2DToConvolution(g);
     passes::UnpackAddMM(g);
+    //passes::UnpackBatchNorm(g);
     passes::UnpackLogSoftmax(g);
     //passes::RemoveDimExeception(g);
     //irfusers::UnpackBatchNorm(g);

--- a/core/lowering/passes/unpack_batch_norm.cpp
+++ b/core/lowering/passes/unpack_batch_norm.cpp
@@ -41,6 +41,9 @@ void UnpackBatchNorm(std::shared_ptr<torch::jit::Graph>& graph) {
     torch::jit::SubgraphRewriter unpack_batch_norm;
     unpack_batch_norm.RegisterRewritePattern(batch_norm_pattern, expanded_batch_norm_pattern);
     unpack_batch_norm.runOnGraph(graph);
+    LOG_DEBUG("[Lowering Batch Norm]: momentum disregarded");
+    LOG_DEBUG("[Lowering Batch Norm]: training disregarded");
+    LOG_DEBUG("[Lowering Batch Norm]: cudnn disregarded");
     LOG_GRAPH("Post unpack batchnorm: " << *graph);
 }
 } // Namespace passes

--- a/tests/core/converters/BUILD
+++ b/tests/core/converters/BUILD
@@ -5,6 +5,10 @@ converter_test(
 )
 
 converter_test(
+  name = "test_batch_norm"
+)
+
+converter_test(
   name = "test_conv"
 )
 
@@ -44,6 +48,7 @@ test_suite(
   name = "test_converters",
   tests = [
     ":test_activation",
+    ":test_batch_norm",
     ":test_conv",
     ":test_element_wise",
     ":test_linear",

--- a/tests/core/converters/test_batch_norm.cpp
+++ b/tests/core/converters/test_batch_norm.cpp
@@ -1,0 +1,36 @@
+#include <string>
+#include "gtest/gtest.h"
+#include "torch/csrc/jit/ir/irparser.h"
+#include "tests/util/util.h"
+#include "core/compiler.h"
+
+TEST(Converters, ATenBatchNormConvertsCorrectly) {
+    const auto graph = R"IR(
+      graph(%0 : Tensor,
+            %1: Float(5),
+            %2: Float(5),
+            %3: Float(5),
+            %4: Float(5)):
+        %5 : bool = prim::Constant[value=0]()
+        %6 : float = prim::Constant[value=1.0000000000000001e-05]()
+        %7 : float = prim::Constant[value=0.10000000000000001]()
+        %8 : Tensor = aten::batch_norm(%0, %1, %2, %3, %4, %5, %6, %7, %5)
+        return (%8))IR";
+
+    auto g = std::make_shared<torch::jit::Graph>();
+    torch::jit::parseIR(graph, &*g);
+
+    auto in = at::randint(1, 10, {1, 5, 5, 5}, {at::kCUDA});
+    auto gamma = at::randint(1, 10, {5}, {at::kCUDA});
+    auto beta = at::randint(1, 10, {5}, {at::kCUDA});
+    auto mean = at::randint(1, 10, {5}, {at::kCUDA});
+    auto var = at::randint(1, 10, {5}, {at::kCUDA});
+
+    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {gamma, beta, mean, var});
+    auto jit_results = trtorch::tests::util::RunGraph(g, params, {in});
+
+    params = trtorch::core::conversion::get_named_params(g->inputs(), {gamma, beta, mean, var});
+    auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {in});
+
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}


### PR DESCRIPTION
Signed-off-by: Naren Dasan <naren@narendasan.com>
Signed-off-by: Naren Dasan <narens@nvidia.com>

# Description

Addresses performance issues seen with large input sizes and the conv based batch norm implementation. This new implementation just uses scale layers instead of conv.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation and have regenerated the documentation (`make html` in docsrc)
- [X] I have added tests to verify my fix or my feature
- [X] New and existing unit tests pass locally with my changes