### PR TITLE
Narendasan/int8 mixed precision fix

### DIFF
--- a/core/conversion/conversionctx/ConversionCtx.cpp
+++ b/core/conversion/conversionctx/ConversionCtx.cpp
@@ -13,7 +13,7 @@ std::ostream& operator<<(std::ostream& os, const BuilderSettings& s) {
        << "\n    Operating Precision: " << s.op_precision                                  \
        << "\n    Make Refittable Engine: " << s.refit                                      \
        << "\n    Debuggable Engine: " << s.debug                                           \
-       << "\n    Strict Type: " << s.strict_types                                          \
+       << "\n    Strict Types: " << s.strict_types                                         \
        << "\n    Allow GPU Fallback (if running on DLA): " << s.allow_gpu_fallback         \
        << "\n    Min Timing Iterations: " << s.num_min_timing_iters                        \
        << "\n    Avg Timing Iterations: " << s.num_avg_timing_iters                        \
@@ -51,7 +51,9 @@ ConversionCtx::ConversionCtx(BuilderSettings build_settings)
     case nvinfer1::DataType::kINT8:
         TRTORCH_CHECK(builder->platformHasFastInt8(), "Requested inference in INT8 but platform does support INT8");
         cfg->setFlag(nvinfer1::BuilderFlag::kINT8);
-        cfg->setFlag(nvinfer1::BuilderFlag::kFP16);
+        if (!settings.strict_types) {
+            cfg->setFlag(nvinfer1::BuilderFlag::kFP16);
+        }
         input_type = nvinfer1::DataType::kFLOAT;
         TRTORCH_CHECK(settings.calibrator != nullptr, "Requested inference in INT8 but no calibrator provided, set the ptq_calibrator field in the ExtraInfo struct with your calibrator");
         cfg->setInt8Calibrator(settings.calibrator);

--- a/core/conversion/conversionctx/ConversionCtx.cpp
+++ b/core/conversion/conversionctx/ConversionCtx.cpp
@@ -51,6 +51,7 @@ ConversionCtx::ConversionCtx(BuilderSettings build_settings)
     case nvinfer1::DataType::kINT8:
         TRTORCH_CHECK(builder->platformHasFastInt8(), "Requested inference in INT8 but platform does support INT8");
         cfg->setFlag(nvinfer1::BuilderFlag::kINT8);
+        cfg->setFlag(nvinfer1::BuilderFlag::kFP16);
         input_type = nvinfer1::DataType::kFLOAT;
         TRTORCH_CHECK(settings.calibrator != nullptr, "Requested inference in INT8 but no calibrator provided, set the ptq_calibrator field in the ExtraInfo struct with your calibrator");
         cfg->setInt8Calibrator(settings.calibrator);

--- a/core/conversion/converters/NodeConverterRegistry.cpp
+++ b/core/conversion/converters/NodeConverterRegistry.cpp
@@ -48,6 +48,10 @@ public:
     bool RegisterConverter(torch::jit::FunctionSchema* signature, OpConverter& converter) {
         LOG_DEBUG("Registering converter for " << canonical_schema_string(*signature));
         auto name = signature->operator_name();
+        auto iter = converter_lut_.find(name);
+        if (iter != converter_lut_.end()) {
+            LOG_WARNING("Overriding already registered converter " << signature->name() << ", unexpected behavior may occur");
+        }
         converter_lut_[name] = std::move(converter);
         return true;
     }

--- a/core/conversion/evaluators/BUILD
+++ b/core/conversion/evaluators/BUILD
@@ -15,7 +15,8 @@ cc_library(
     srcs = [
         "NodeEvaluatorRegistry.cpp",
         "prim.cpp",
-        "aten.cpp"
+        "aten.cpp",
+        "eval_macros.h"
     ],
     deps = [
         "//core/util:prelude",

--- a/core/conversion/evaluators/NodeEvaluatorRegistry.cpp
+++ b/core/conversion/evaluators/NodeEvaluatorRegistry.cpp
@@ -30,6 +30,10 @@ class NodeEvaluatorRegistry {
 public:
     void RegisterEvaluator(torch::jit::NodeKind node_kind, EvalRegistration eval_reg) {
         LOG_DEBUG("Registering evaluator for " << node_kind.toQualString());
+        auto iter = evaluator_lut_.find(node_kind);
+        if (iter != evaluator_lut_.end()) {
+            TRTORCH_THROW_ERROR("Attempting to override already registered evaluator " << node_kind.toQualString() << ", merge implementations instead");
+        }
         evaluator_lut_[node_kind] = std::move(eval_reg);
     }
 

--- a/core/conversion/evaluators/aten.cpp
+++ b/core/conversion/evaluators/aten.cpp
@@ -8,13 +8,13 @@
 #include "torch/torch.h"
 
 #include "core/conversion/evaluators/evaluators.h"
+#include "core/conversion/evaluators/eval_macros.h"
 
 namespace trtorch {
 namespace core {
 namespace conversion {
 namespace evaluators {
 namespace {
-
 
 int64_t normalizeIndex(int64_t idx, int64_t list_size) {
     if (idx < 0) {
@@ -24,7 +24,90 @@ int64_t normalizeIndex(int64_t idx, int64_t list_size) {
     return idx;
 }
 
-auto aten_registrations = RegisterNodeEvaluators()
+DEFINE_GENERIC_TWO_INPUT_EVALUATOR(
+    eq,
+    "aten::eq",
+    a == b,
+    std::set<std::string>({
+        "aten::eq.bool(bool a, bool b) -> (bool)",
+        "aten::eq.int(int a, int b) -> (bool)",
+        "aten::eq.float(float a, float b) -> (bool)",
+        "aten::eq.int_float(int a, float b) -> (bool)",
+        "aten::eq.float_int(float a, int b) -> (bool)",
+    })
+);
+
+DEFINE_GENERIC_TWO_INPUT_EVALUATOR(
+    ne,
+    "aten::ne",
+    a != b,
+    std::set<std::string>({
+        "aten::ne.bool(bool a, bool b) -> (bool)",
+        "aten::ne.int(int a, int b) -> (bool)",
+        "aten::ne.float(float a, float b) -> (bool)",
+        "aten::ne.int_float(int a, float b) -> (bool)",
+        "aten::ne.float_int(float a, int b) -> (bool)",
+    })
+);
+
+DEFINE_GENERIC_TWO_INPUT_EVALUATOR(
+    lt,
+    "aten::lt",
+    a < b,
+    std::set<std::string>({
+        "aten::lt.bool(bool a, bool b) -> (bool)",
+        "aten::lt.int(int a, int b) -> (bool)",
+        "aten::lt.float(float a, float b) -> (bool)",
+        "aten::lt.int_float(int a, float b) -> (bool)",
+        "aten::lt.float_int(float a, int b) -> (bool)",
+    })
+);
+
+DEFINE_GENERIC_TWO_INPUT_EVALUATOR(
+    gt,
+    "aten::gt",
+    a > b,
+    std::set<std::string>({
+        "aten::gt.bool(bool a, bool b) -> (bool)",
+        "aten::gt.int(int a, int b) -> (bool)",
+        "aten::gt.float(float a, float b) -> (bool)",
+        "aten::gt.int_float(int a, float b) -> (bool)",
+        "aten::gt.float_int(float a, int b) -> (bool)",
+    })
+);
+
+DEFINE_GENERIC_TWO_INPUT_EVALUATOR(
+    le,
+    "aten::le",
+    a <= b,
+    std::set<std::string>({
+        "aten::le.bool(bool a, bool b) -> (bool)",
+        "aten::le.int(int a, int b) -> (bool)",
+        "aten::le.float(float a, float b) -> (bool)",
+        "aten::le.int_float(int a, float b) -> (bool)",
+        "aten::le.float_int(float a, int b) -> (bool)",
+    })
+);
+
+DEFINE_GENERIC_TWO_INPUT_EVALUATOR(
+    ge,
+    "aten::ge",
+    a >= b,
+    std::set<std::string>({
+        "aten::ge.bool(bool a, bool b) -> (bool)",
+        "aten::ge.int(int a, int b) -> (bool)",
+        "aten::ge.float(float a, float b) -> (bool)",
+        "aten::ge.int_float(int a, float b) -> (bool)",
+        "aten::ge.float_int(float a, int b) -> (bool)",
+    })
+);
+
+DEFINE_TWO_INPUT_SIMPLE_EVALUATOR(and, "aten::__and__", a && b, bool, {"aten::__and__(int a, int b) -> (bool)"});
+DEFINE_TWO_INPUT_SIMPLE_EVALUATOR(or, "aten::__or__", a || b, bool, {"aten::__or__(int a, int b) -> (bool)"});
+DEFINE_TWO_INPUT_SIMPLE_EVALUATOR(xor, "aten::__xor__", a != b, bool, {"aten::__xor__(int a, int b) -> (bool)"});
+DEFINE_TWO_INPUT_SIMPLE_EVALUATOR(int_div, "aten::__round_to_zero_floordiv", a / b, int64_t, {"aten::__round_to_zero_floordiv(int a, int b) -> (int)"});
+
+auto aten_registrations TRTORCH_UNUSED = RegisterNodeEvaluators()
     .evaluator({
         c10::Symbol::fromQualString("aten::zeros"),
         // aten::zeros(int[] size, *, int? dtype=None, int? layout=None, Device? device=None, bool? pin_memory=None) -> (Tensor)
@@ -37,38 +120,6 @@ auto aten_registrations = RegisterNodeEvaluators()
             auto out_tensor = torch::zeros(args.at(n->input(0)).unwrapToIntList().vec(), options);
             return out_tensor;
         }
-    }).evaluator({
-        c10::Symbol::fromQualString("aten::add"),
-        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
-            auto a = args.at(n->input(0)).unwrapToInt();
-            auto b = args.at(n->input(1)).unwrapToInt();
-            return a + b;
-        },
-        EvalOptions().validSchemas({"aten::add.int(int a, int b) -> (int)"})
-    }).evaluator({
-        c10::Symbol::fromQualString("aten::mul"),
-        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
-            auto a = args.at(n->input(0)).unwrapToInt();
-            auto b = args.at(n->input(1)).unwrapToInt();
-            return a * b;
-        },
-        EvalOptions().validSchemas({"aten::mul.int(int a, int b) -> (int)"})
-    }).evaluator({
-        c10::Symbol::fromQualString("aten::sub"),
-        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
-            auto a = args.at(n->input(0)).unwrapToInt();
-            auto b = args.at(n->input(1)).unwrapToInt();
-            return a - b;
-        },
-        EvalOptions().validSchemas({"aten::sub.int(int a, int b) -> (int)"})
-    }).evaluator({
-        c10::Symbol::fromQualString("aten::__round_to_zero_floordiv"),
-        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
-            auto a = args.at(n->input(0)).unwrapToInt();
-            auto b = args.at(n->input(1)).unwrapToInt();
-            return a / b;
-        },
-        EvalOptions().validSchemas({"aten::__round_to_zero_floordiv(int a, int b) -> (int)"})
     }).evaluator({
         c10::Symbol::fromQualString("aten::slice"),
         [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
@@ -139,7 +190,7 @@ auto aten_registrations = RegisterNodeEvaluators()
     }).evaluator({
         c10::Symbol::fromQualString("aten::__getitem__"),
         [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
-            auto list = args.at(n->input(0)).unwrapToIntList();
+            auto list = args.at(n->input(0)).IValue()->to<c10::List<c10::IValue>>();
             auto idx = args.at(n->input(1)).unwrapToInt();
 
             const int64_t list_size = list.size();
@@ -153,8 +204,8 @@ auto aten_registrations = RegisterNodeEvaluators()
     }).evaluator({
         c10::Symbol::fromQualString("aten::append"),
         [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
-            auto list = args.at(n->input(0)).unwrapToIntList();
-            auto el = args.at(n->input(1)).unwrapToInt();
+            auto list = args.at(n->input(0)).IValue()->to<c10::List<c10::IValue>>();
+            auto el = args.at(n->input(1)).IValue();
 
             list.push_back(std::move(el));
             return list;
@@ -172,6 +223,226 @@ auto aten_registrations = RegisterNodeEvaluators()
         EvalOptions().validSchemas({
             "aten::neg.int(int a) -> (int)",
         })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::add"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            if (args.at(n->input(0)).IValue()->isInt()) {
+                auto a = args.at(n->input(0)).unwrapToInt();
+                auto b = args.at(n->input(1)).unwrapToInt();
+                return a + b;
+            } else if (args.at(n->input(0)).IValue()->isDouble()) {
+                auto a = args.at(n->input(0)).unwrapToDouble();
+                auto b = args.at(n->input(1)).unwrapToDouble();
+                return a + b;
+            } else {
+                TRTORCH_THROW_ERROR("Unimplemented data type for aten::add evaluator: " << args.at(n->input(0)).IValue()->type()->str());
+                return {};
+            }
+        },
+        EvalOptions().validSchemas({
+            "aten::add.int(int a, int b) -> (int)",
+            "aten::add.float(float a, float b) -> (float)"
+        })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::mul"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            if (args.at(n->input(0)).IValue()->isInt()) {
+                auto a = args.at(n->input(0)).unwrapToInt();
+                auto b = args.at(n->input(1)).unwrapToInt();
+                return a * b;
+            } else if (args.at(n->input(0)).IValue()->isDouble()) {
+                auto a = args.at(n->input(0)).unwrapToDouble();
+                auto b = args.at(n->input(1)).unwrapToDouble();
+                return a * b;
+            } else {
+                TRTORCH_THROW_ERROR("Unimplemented data type for aten::mul evaluator: " << args.at(n->input(0)).IValue()->type()->str());
+                return {};
+            }
+        },
+        EvalOptions().validSchemas({
+            "aten::mul.int(int a, int b) -> (int)",
+            "aten::mul.float(float a, float b) -> (float)"
+        })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::sub"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            if (args.at(n->input(0)).IValue()->isInt()) {
+                auto a = args.at(n->input(0)).unwrapToInt();
+                auto b = args.at(n->input(1)).unwrapToInt();
+                return a - b;
+            } else if (args.at(n->input(0)).IValue()->isDouble()) {
+                auto a = args.at(n->input(0)).unwrapToDouble();
+                auto b = args.at(n->input(1)).unwrapToDouble();
+                return a - b;
+            } else {
+                TRTORCH_THROW_ERROR("Unimplemented data type for aten::sub evaluator: " << args.at(n->input(0)).IValue()->type()->str());
+                return {};
+            }
+        },
+        EvalOptions().validSchemas({
+            "aten::sub.float(float a, float b) -> (float)",
+            "aten::sub.int(int a, int b) -> (int)",
+        })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::Bool"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            if (args.at(n->input(0)).IValue()->isInt()) {
+                auto a = args.at(n->input(0)).unwrapToInt();
+                return (bool) a;
+            } else if (args.at(n->input(0)).IValue()->isDouble()) {
+                auto a = args.at(n->input(0)).unwrapToDouble();
+                return (bool) a;
+            } else {
+                TRTORCH_THROW_ERROR("Unimplemented data type for aten::Bool evaluator: " << args.at(n->input(0)).IValue()->type()->str());
+                return {};
+            }
+        },
+        EvalOptions().validSchemas({
+            "aten::Bool.int(int a) -> (bool)",
+            "aten::Bool.float(float b) -> (bool)"
+        })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::Float"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            if (args.at(n->input(0)).IValue()->isInt()) {
+                auto a = args.at(n->input(0)).unwrapToInt();
+                return (float) a;
+            } else if (args.at(n->input(0)).IValue()->isDouble()) {
+                auto a = args.at(n->input(0)).unwrapToDouble();
+                return (float) a;
+            }  else if (args.at(n->input(0)).IValue()->isBool()) {
+                auto a = args.at(n->input(0)).unwrapToBool();
+                return (float) a;
+            } else {
+                TRTORCH_THROW_ERROR("Unimplemented data type for aten::Float evaluator: " << args.at(n->input(0)).IValue()->type()->str());
+                return {};
+            }
+        },
+        EvalOptions().validSchemas({
+            "aten::Float.Scalar(Scalar a) -> float",
+            "aten::Float.int(int a) -> float",
+            "aten::Float.bool(bool a) -> float",
+        })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::__not__"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            auto el = args.at(n->input(0)).unwrapToBool();
+
+            return !el;
+        },
+        EvalOptions().validSchemas({
+            "aten::__not__(bool self) -> bool",
+        })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::__is__"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            auto self = args.at(n->input(0)).IValue();
+            auto obj = args.at(n->input(1)).IValue();
+
+            return self->isSameIdentity(*obj);
+        },
+        EvalOptions().validSchemas({
+            "aten::__is__(t1 self, t2 obj) -> bool",
+        })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::__isnot__"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            auto self = args.at(n->input(0)).IValue();
+            auto obj = args.at(n->input(1)).IValue();
+
+            return !self->isSameIdentity(*obj);
+        },
+        EvalOptions().validSchemas({
+            "aten::__isnot__(t1 self, t2 obj) -> bool",
+        })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::numel"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            LOG_WARNING("There may be undefined behavior using dynamic shape and aten::numel");
+            auto tensor_var = args.at(n->input(0));
+            if (tensor_var.isITensor()) {
+                auto tensor = tensor_var.ITensor();
+                return util::volume(tensor->getDimensions());
+            } else {
+                auto tensor = tensor_var.unwrapToTensor();
+                return tensor.numel();
+            }
+        },
+        EvalOptions().validSchemas({
+            "aten::numel(Tensor self) -> int",
+        })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::dim"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            auto tensor_var = args.at(n->input(0));
+            if (tensor_var.isITensor()) {
+                auto tensor = tensor_var.ITensor();
+                return tensor->getDimensions().nbDims;
+            } else {
+                auto tensor = tensor_var.unwrapToTensor();
+                return tensor.dim();
+            }
+        },
+        EvalOptions().validSchemas({
+            "aten::dim(Tensor self) -> int",
+        })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::div"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            if (args.at(n->input(0)).IValue()->isInt()) {
+                auto a = args.at(n->input(0)).unwrapToInt();
+                auto b = args.at(n->input(1)).unwrapToInt();
+                return static_cast<double>(a) / static_cast<double>(b);
+            } else if (args.at(n->input(0)).IValue()->isDouble()) {
+                auto a = args.at(n->input(0)).unwrapToDouble();
+                auto b = args.at(n->input(1)).unwrapToDouble();
+                return a / b;
+            } else {
+                TRTORCH_THROW_ERROR("Unimplemented data type for aten::div evaluator: " << args.at(n->input(0)).IValue()->type()->str());
+                return {};
+            }
+        },
+        EvalOptions().validSchemas({
+            "aten::div.Scalar(Scalar a, Scalar b) -> (float)",
+        })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::floordiv"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            if (args.at(n->input(0)).IValue()->isInt()) {
+                auto a = args.at(n->input(0)).unwrapToInt();
+                auto b = args.at(n->input(1)).unwrapToInt();
+                return std::floor(a / b);
+            } else if (args.at(n->input(0)).IValue()->isDouble()) {
+                auto a = args.at(n->input(0)).unwrapToDouble();
+                auto b = args.at(n->input(1)).unwrapToDouble();
+                return std::floor(a / b);
+            } else {
+                TRTORCH_THROW_ERROR("Unimplemented data type for aten::floordiv evaluator: " << args.at(n->input(0)).IValue()->type()->str());
+                return {};
+            }
+        },
+        EvalOptions().validSchemas({
+            "aten::floordiv.float(float a, float b) -> (int)",
+            "aten::floordiv.int(int a, int b) -> (int)",
+        })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::floor"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            auto el = args.at(n->input(0)).unwrapToDouble();
+
+            return std::floor(el);
+        },
+        EvalOptions().validSchemas({
+            "aten::floor.float(float a) -> (int)",
+        })
+    }).evaluator({
+        c10::Symbol::fromQualString("aten::warn"),
+        [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
+            auto warning = args.at(n->input(0)).IValue()->toString();
+            LOG_WARNING(warning);
+            return {};
+        },
+        EvalOptions()
     });
 }
 } // namespace evaluators

--- a/core/conversion/evaluators/eval_macros.h
+++ b/core/conversion/evaluators/eval_macros.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "core/conversion/evaluators/evaluators.h"
+
+#define DEFINE_GENERIC_TWO_INPUT_EVALUATOR(name, node_kind, operation, schemas)                    \
+  auto name##_registrations TRTORCH_UNUSED =                                                       \
+    RegisterNodeEvaluators().evaluator({                                                           \
+      c10::Symbol::fromQualString(node_kind),                                                      \
+      [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {           \
+        if (args.at(n->input(0)).IValue()->isInt()) {                                              \
+          auto a = args.at(n->input(0)).unwrapToInt();                                             \
+          if (args.at(n->input(1)).IValue()->isInt()) {                                            \
+            auto b = args.at(n->input(1)).unwrapToInt();                                           \
+            return operation;                                                                      \
+          } else if (args.at(n->input(1)).IValue()->isDouble()) {                                  \
+            auto b = args.at(n->input(1)).unwrapToDouble();                                        \
+            return operation;                                                                      \
+          } else if (args.at(n->input(1)).IValue()->isBool()) {                                    \
+            auto b = args.at(n->input(1)).unwrapToBool();                                          \
+            return operation;                                                                      \
+          } else {                                                                                 \
+            TRTORCH_THROW_ERROR("Unimplemented data type for " << node_kind << " evaluator b arg:" \
+                << args.at(n->input(1)).IValue()->type()->str());                                  \
+            return {};                                                                             \
+          }                                                                                        \
+        } else if (args.at(n->input(0)).IValue()->isDouble()) {                                    \
+          auto a = args.at(n->input(0)).unwrapToDouble();                                          \
+          if (args.at(n->input(1)).IValue()->isInt()) {                                            \
+            auto b = args.at(n->input(1)).unwrapToInt();                                           \
+            return operation;                                                                      \
+          } else if (args.at(n->input(1)).IValue()->isDouble()) {                                  \
+            auto b = args.at(n->input(1)).unwrapToDouble();                                        \
+            return operation;                                                                      \
+          } else if (args.at(n->input(1)).IValue()->isBool()) {                                    \
+            auto b = args.at(n->input(1)).unwrapToBool();                                          \
+            return operation;                                                                      \
+          } else {                                                                                 \
+            TRTORCH_THROW_ERROR("Unimplemented data type for " << node_kind << " evaluator b arg:" \
+                << args.at(n->input(1)).IValue()->type()->str());                                  \
+            return {};                                                                             \
+          }                                                                                        \
+        } else if (args.at(n->input(0)).IValue()->isBool()) {                                      \
+          auto a = args.at(n->input(0)).unwrapToBool();                                            \
+          if (args.at(n->input(1)).IValue()->isInt()) {                                            \
+            auto b = args.at(n->input(1)).unwrapToInt();                                           \
+            return operation;                                                                      \
+          } else if (args.at(n->input(1)).IValue()->isDouble()) {                                  \
+            auto b = args.at(n->input(1)).unwrapToDouble();                                        \
+            return operation;                                                                      \
+          } else if (args.at(n->input(1)).IValue()->isBool()) {                                    \
+            auto b = args.at(n->input(1)).unwrapToBool();                                          \
+            return operation;                                                                      \
+          } else {                                                                                 \
+            TRTORCH_THROW_ERROR("Unimplemented data type for " << node_kind << " evaluator b arg:" \
+                << args.at(n->input(1)).IValue()->type()->str());                                  \
+            return {};                                                                             \
+          }                                                                                        \
+        } else {                                                                                   \
+          TRTORCH_THROW_ERROR("Unimplemented data type for " << node_kind << " evaluator a arg: "  \
+            << args.at(n->input(0)).IValue()->type()->str());                                      \
+          return {};                                                                               \
+        }                                                                                          \
+      },                                                                                           \
+      EvalOptions().validSchemas(schemas)                                                          \
+    });
+
+#define DEFINE_TWO_INPUT_SIMPLE_EVALUATOR(node_kind, node_name, operation, type, schemas) \
+  auto node_kind##_registrations TRTORCH_UNUSED =                                         \
+    RegisterNodeEvaluators().evaluator({                                                  \
+      c10::Symbol::fromQualString(node_name),                                             \
+      [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {  \
+        auto a = args.at(n->input(0)).unwrapTo<type>();                                   \
+        auto b = args.at(n->input(1)).unwrapTo<type>();                                   \
+        return operation;                                                                 \
+      },                                                                                  \
+      EvalOptions().validSchemas(schemas)                                                 \
+    });


### PR DESCRIPTION
# Description

When int8 is enabled, we also need to enable fp16 kernels just in case those kernels provide a faster path. This explains significant performance differences between FP16 and INT8 in cases where most layers are not mapped to INT8 kernels. 

Partially addresses #93 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation and have regenerated the documentation (`make html` in docsrc)
- [ ] I have added tests to verify my fix or my feature
- [X] New and existing unit tests pass locally with my changes