### PR TITLE
Enable FP16 mixed precision with Int8

### DIFF
--- a/core/conversion/conversionctx/ConversionCtx.cpp
+++ b/core/conversion/conversionctx/ConversionCtx.cpp
@@ -13,7 +13,7 @@ std::ostream& operator<<(std::ostream& os, const BuilderSettings& s) {
        << "\n    Operating Precision: " << s.op_precision                                  \
        << "\n    Make Refittable Engine: " << s.refit                                      \
        << "\n    Debuggable Engine: " << s.debug                                           \
-       << "\n    Strict Type: " << s.strict_types                                          \
+       << "\n    Strict Types: " << s.strict_types                                         \
        << "\n    Allow GPU Fallback (if running on DLA): " << s.allow_gpu_fallback         \
        << "\n    Min Timing Iterations: " << s.num_min_timing_iters                        \
        << "\n    Avg Timing Iterations: " << s.num_avg_timing_iters                        \
@@ -51,7 +51,9 @@ ConversionCtx::ConversionCtx(BuilderSettings build_settings)
     case nvinfer1::DataType::kINT8:
         TRTORCH_CHECK(builder->platformHasFastInt8(), "Requested inference in INT8 but platform does support INT8");
         cfg->setFlag(nvinfer1::BuilderFlag::kINT8);
-        cfg->setFlag(nvinfer1::BuilderFlag::kFP16);
+        if (!settings.strict_types) {
+            cfg->setFlag(nvinfer1::BuilderFlag::kFP16);
+        }
         input_type = nvinfer1::DataType::kFLOAT;
         TRTORCH_CHECK(settings.calibrator != nullptr, "Requested inference in INT8 but no calibrator provided, set the ptq_calibrator field in the ExtraInfo struct with your calibrator");
         cfg->setInt8Calibrator(settings.calibrator);

--- a/core/conversion/conversionctx/ConversionCtx.cpp
+++ b/core/conversion/conversionctx/ConversionCtx.cpp
@@ -51,6 +51,7 @@ ConversionCtx::ConversionCtx(BuilderSettings build_settings)
     case nvinfer1::DataType::kINT8:
         TRTORCH_CHECK(builder->platformHasFastInt8(), "Requested inference in INT8 but platform does support INT8");
         cfg->setFlag(nvinfer1::BuilderFlag::kINT8);
+        cfg->setFlag(nvinfer1::BuilderFlag::kFP16);
         input_type = nvinfer1::DataType::kFLOAT;
         TRTORCH_CHECK(settings.calibrator != nullptr, "Requested inference in INT8 but no calibrator provided, set the ptq_calibrator field in the ExtraInfo struct with your calibrator");
         cfg->setInt8Calibrator(settings.calibrator);


### PR DESCRIPTION
# Description

When int8 is enabled, we also need to enable fp16 kernels just in case those kernels provide a faster path. This explains significant performance differences between FP16 and INT8 in cases where most layers are not mapped to INT8 kernels. 

Partially addresses #93 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation and have regenerated the documentation (`make html` in docsrc)
- [ ] I have added tests to verify my fix or my feature
- [X] New and existing unit tests pass locally with my changes