### PR TITLE
fix(aten::flatten): Fixes dynamic shape for flatten

### DIFF
--- a/core/conversion/converters/impl/shuffle.cpp
+++ b/core/conversion/converters/impl/shuffle.cpp
@@ -17,7 +17,12 @@ static auto shuffle_registrations TRTORCH_UNUSED = RegisterNodeConversionPattern
       auto start_dim = args[1].unwrapToInt();
       auto end_dim = args[2].unwrapToInt();
       auto in_shape = util::toVec(in->getDimensions());
-      auto out_shape = torch::flatten(torch::rand(in_shape), start_dim, end_dim).sizes();
+      std::vector<int64_t> out_shape;
+      if (ctx->input_is_dynamic) {
+        out_shape = std::vector<int64_t>({in_shape[0], -1});
+      } else {
+        out_shape = torch::flatten(torch::rand(in_shape), start_dim, end_dim).sizes().vec();
+      }
 
       auto shuffle = ctx->net->addShuffle(*in);
       TRTORCH_CHECK(shuffle, "Unable to create shuffle layer from node: " << *n);
@@ -33,7 +38,12 @@ static auto shuffle_registrations TRTORCH_UNUSED = RegisterNodeConversionPattern
     [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
       auto in = args[0].ITensor();
       auto in_shape = util::toVec(in->getDimensions());
-      auto new_shape = torch::reshape(torch::rand(in_shape), args[1].unwrapToIntList().vec()).sizes();
+      std::vector<int64_t> new_shape;
+      if (ctx->input_is_dynamic) {
+        TRTORCH_THROW_ERROR("Resize is currently not support in dynamic input shape compilation");
+      } else {
+        new_shape = torch::reshape(torch::rand(in_shape), args[1].unwrapToIntList().vec()).sizes().vec();
+      }
 
       auto shuffle = ctx->net->addShuffle(*in);
       TRTORCH_CHECK(shuffle, "Unable to create shuffle layer from node: " << *n);


### PR DESCRIPTION
# Description

Fixes flatten to work with dynamic input. Also will now error out on dynamic input and resize (issue to be filed for a shape tensor runtime evaluation system)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas and hacks
- [X] I have made corresponding changes to the documentation and have regenerated the documentation (`make html` in docsrc)
- [X] I have added tests to verify my fix or my feature
- [X] New and existing unit tests pass locally with my changes