### PR TITLE
Fix for interpolate plugin segfault

### DIFF
--- a/core/conversion/converters/impl/conv_deconv.cpp
+++ b/core/conversion/converters/impl/conv_deconv.cpp
@@ -45,6 +45,9 @@ auto conv_registrations TRTORCH_UNUSED = RegisterNodeConversionPatterns()
 
                 deconv->setStrideNd(stride);
                 deconv->setPaddingNd(padding);
+                deconv->setDilationNd(dilation);
+                deconv->setNbGroups(groups);
+
                 new_layer = deconv;
             } else {
                 nvinfer1::IConvolutionLayer* conv;

--- a/core/conversion/converters/impl/interpolate.cpp
+++ b/core/conversion/converters/impl/interpolate.cpp
@@ -21,7 +21,7 @@ void create_plugin(ConversionCtx* ctx, const torch::jit::Node* n, nvinfer1::ITen
                                                                                          std::vector<int64_t> out_shape,
                                                                                          std::vector<int64_t> out_size,
                                                                                          std::string mode) {
-    LOG_WARNING("Interpolation layer will be run through ATen, not TensorRT. Performance may differ.");
+    LOG_WARNING("Interpolation layer will be run through ATen, not TensorRT. Performance may be lower than expected");
 
     auto creator = new plugins::InterpolatePluginCreator();
     auto plugin = creator->createPlugin(name, in_shape, out_shape, out_size, mode, false);

--- a/core/conversion/converters/impl/plugins/BUILD
+++ b/core/conversion/converters/impl/plugins/BUILD
@@ -24,6 +24,12 @@ cc_library(
         "//conditions:default":  ["@libtorch//:libtorch"],
     }),
     alwayslink = True,
+    copts = [
+        "-pthread"
+    ],
+    linkopts = [
+        "-lpthread",
+    ]
 )
 
 load("@rules_pkg//:pkg.bzl", "pkg_tar")

--- a/core/conversion/converters/impl/plugins/interpolate_plugin.cpp
+++ b/core/conversion/converters/impl/plugins/interpolate_plugin.cpp
@@ -9,57 +9,57 @@ namespace converters {
 namespace impl {
 namespace plugins {
 
-/* 
+/*
  * InterpolatePlugin class implementations
  */
 
-InterpolatePlugin::InterpolatePlugin(std::vector<int64_t> in_shape, std::vector<int64_t> out_shape, std::vector<int64_t> size, std::string mode, bool align_corners) : 
-    in_shape(in_shape), out_shape(out_shape), size(size), mode(mode), align_corners(align_corners) 
+InterpolatePlugin::InterpolatePlugin(std::vector<int64_t> in_shape, std::vector<int64_t> out_shape, std::vector<int64_t> size, std::string mode, bool align_corners) :
+    in_shape_(in_shape), out_shape_(out_shape), size_(size), mode_(mode), align_corners_(align_corners)
 {}
 
 InterpolatePlugin::InterpolatePlugin(const char *data, size_t length) {
     std::istringstream data_stream(std::string(data, length));
-    
+
     torch::serialize::InputArchive input_archive;
     input_archive.load_from(data_stream);
-    
+
     {
         torch::IValue value;
         input_archive.read("in_shape", value);
-        in_shape = value.toIntVector();
+        in_shape_ = value.toIntVector();
     }
     {
         torch::IValue value;
         input_archive.read("out_shape", value);
-        out_shape = value.toIntVector();
+        out_shape_ = value.toIntVector();
     }
     {
         torch::IValue value;
         input_archive.read("size", value);
-        size = value.toIntVector();
+        size_ = value.toIntVector();
     }
     {
         torch::IValue value;
         input_archive.read("mode", value);
-        mode = value.toStringRef();
+        mode_ = value.toStringRef();
     }
     {
         torch::IValue value;
         input_archive.read("align_corners", value);
-        align_corners = value.toBool();
+        align_corners_ = value.toBool();
     }
 }
 
 std::vector<int64_t> InterpolatePlugin::getInputShape() {
-    return in_shape;
+    return in_shape_;
 }
 
 std::vector<int64_t> InterpolatePlugin::getOutputShape() {
-    return out_shape;
+    return out_shape_;
 }
 
 std::vector<int64_t> InterpolatePlugin::getOutputSize() {
-    return size;
+    return size_;
 }
 
 int InterpolatePlugin::getNbOutputs() const {
@@ -80,14 +80,14 @@ const char* InterpolatePlugin::getPluginNamespace() const {
 
 
 nvinfer1::IPluginV2DynamicExt* InterpolatePlugin::clone() const {
-    return new InterpolatePlugin(in_shape, out_shape, size, mode, align_corners);
+    return new InterpolatePlugin(in_shape_, out_shape_, size_, mode_, align_corners_);
 }
 
 nvinfer1::DimsExprs InterpolatePlugin::getOutputDimensions(int outputIndex, const nvinfer1::DimsExprs *inputs, int nbInputs, nvinfer1::IExprBuilder &exprBuilder) {
    nvinfer1::DimsExprs output(inputs[0]);
 
-   for (unsigned int i = 0; i < out_shape.size(); i++) {
-       output.d[i] = exprBuilder.constant(out_shape[i]);
+   for (unsigned int i = 0; i < out_shape_.size(); i++) {
+       output.d[i] = exprBuilder.constant(out_shape_[i]);
    }
 
    return output;
@@ -98,10 +98,10 @@ nvinfer1::DataType InterpolatePlugin::getOutputDataType(int index, const nvinfer
 }
 
 int InterpolatePlugin::initialize() {
-    tensor_options = tensor_options.device(c10::kCUDA);
+    tensor_options_ = tensor_options_.device(c10::kCPU);
 
     // c10::kFloat = FLOAT32
-    tensor_options = tensor_options.dtype(c10::kFloat);
+    tensor_options_ = tensor_options_.dtype(c10::kFloat);
 
     return 0;
 }
@@ -117,11 +117,11 @@ void InterpolatePlugin::serialize(void* buffer) const {
 std::string InterpolatePlugin::serializeToString() const {
     torch::serialize::OutputArchive output_archive;
 
-    output_archive.write("in_shape", torch::IValue(in_shape));
-    output_archive.write("out_shape", torch::IValue(out_shape));
-    output_archive.write("size", torch::IValue(size));
-    output_archive.write("mode", torch::IValue(mode));
-    output_archive.write("align_corners", torch::IValue(align_corners));
+    output_archive.write("in_shape", torch::IValue(in_shape_));
+    output_archive.write("out_shape", torch::IValue(out_shape_));
+    output_archive.write("size", torch::IValue(size_));
+    output_archive.write("mode", torch::IValue(mode_));
+    output_archive.write("align_corners", torch::IValue(align_corners_));
 
     std::ostringstream data_str;
     output_archive.save_to(data_str);
@@ -146,56 +146,48 @@ bool InterpolatePlugin::supportsFormatCombination(int pos, const nvinfer1::Plugi
 
     // pos == 1, accessing information about output tensor
     const PluginTensorDesc& out = inOut[1];
-    
+
     return (in.type == out.type) && (in.format == out.format);
 }
 
 void InterpolatePlugin::configurePlugin(const nvinfer1::DynamicPluginTensorDesc* in, int nbInputs, const nvinfer1::DynamicPluginTensorDesc* out, int nbOutputs) {
-    dtype = DataType::kFLOAT;
+    dtype_ = DataType::kFLOAT;
 }
 
 size_t InterpolatePlugin::getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs, int nbInputs, const nvinfer1::PluginTensorDesc* outputs, int nbOutputs) const {
     return 0;
 }
 
-int InterpolatePlugin::enqueue(const nvinfer1::PluginTensorDesc* inputDesc, const nvinfer1::PluginTensorDesc* outputDesc, const void *const *inputs, 
-                                                                                                        void *const *outputs, void *workspace, 
+int InterpolatePlugin::enqueue(const nvinfer1::PluginTensorDesc* inputDesc, const nvinfer1::PluginTensorDesc* outputDesc, const void* const* inputs,
+                                                                                                        void* const* outputs, void* workspace,
                                                                                                         cudaStream_t stream) {
-    at::Tensor input = at::from_blob((void*) inputs[0], util::toVec(inputDesc->dims), [](void*){}, tensor_options);
-    at::Tensor output = at::from_blob(outputs[0], out_shape, [](void*){}, tensor_options);
+    // TODO: When PyTorch updates to cuDNN 8 try moving back to CUDA based ATen kernels
+    // HACK: WAR because there is a segfault if you try to create a CUDA Tensor in the context of TensorRT execution
+    float* input_blob = (float*) malloc(util::volume(inputDesc->dims) * sizeof(float));
+    cudaMemcpyAsync(input_blob, static_cast<const void*>(inputs[0]), util::volume(inputDesc->dims) * sizeof(float), cudaMemcpyDeviceToHost, stream);
+    cudaStreamSynchronize(stream);
 
-    at::cuda::CUDAStream torch_stream = at::cuda::getStreamFromPool();
-    at::cuda::CUDAStreamGuard torch_guard(torch_stream);
+    at::Tensor input = at::from_blob((void*)input_blob, util::toVec(inputDesc->dims), tensor_options_);
 
-    cudaEvent_t event;
-    cudaEventCreate(&event);
-    cudaEventRecord(event, stream);
-
-    cudaStreamWaitEvent(torch_stream.stream(), event, 0);
-
-    if (mode == "linear") {
-        at::upsample_linear1d_out(output, input, {size[0]}, align_corners);
-    } else if (mode == "bilinear") {
-        at::upsample_bilinear2d_out(output, input, {size[0], size[1]}, align_corners);
-    } else if (mode == "trilinear") {
-        at::upsample_trilinear3d_out(output, input, {size[0], size[1], size[2]}, align_corners);
-    } else if (mode == "adaptive_pool2d") {
-        at::adaptive_avg_pool2d_out(output, input, {size[0], size[1]});
+    at::Tensor output;
+    if (mode_ == "adaptive_pool2d") {
+        output = at::adaptive_avg_pool2d(input, {size_[0], size_[1]});
     }
 
-    cudaEvent_t torch_event;
-    cudaEventCreate(&torch_event);
-    cudaEventRecord(torch_event, torch_stream.stream());
+    output = output.contiguous();
+    for (int i = 0; i < util::volume(outputDesc->dims); i++) {
+        std::cout << ((float*)output.data_ptr())[i] << std::endl;
+    }
 
-    cudaStreamWaitEvent(stream, torch_event, 0);
+    cudaMemcpyAsync(outputs[0], output.data_ptr(), util::volume(outputDesc->dims) * sizeof(float), cudaMemcpyHostToDevice, stream);
+    cudaStreamSynchronize(stream);
 
-    cudaEventDestroy(event);
-    cudaEventDestroy(torch_event);
+    free(input_blob);
 
     return 0;
 }
 
-/* 
+/*
  * InterpolatePluginCreator class implementations
  */
 const char* InterpolatePluginCreator::getPluginNamespace() const {
@@ -214,15 +206,15 @@ nvinfer1::IPluginV2* InterpolatePluginCreator::createPlugin(const char* name, co
     return nullptr;
 }
 
-InterpolatePlugin* InterpolatePluginCreator::createPlugin(const char* name, std::vector<int64_t> in_shape, std::vector<int64_t> out_shape, 
-                                                                                                           std::vector<int64_t> size, 
+InterpolatePlugin* InterpolatePluginCreator::createPlugin(const char* name, std::vector<int64_t> in_shape, std::vector<int64_t> out_shape,
+                                                                                                           std::vector<int64_t> size,
                                                                                                            std::string mode, bool align_corners) {
-    name = name;
+    name_ = name;
     return new InterpolatePlugin(in_shape, out_shape, size, mode, align_corners);
 }
 
 nvinfer1::IPluginV2* InterpolatePluginCreator::deserializePlugin(const char* name, const void *serialData, size_t serialLength) {
-    name = name;
+    name_ = name;
     return new InterpolatePlugin((const char*) serialData, serialLength);
 }
 

--- a/core/conversion/converters/impl/plugins/interpolate_plugin.h
+++ b/core/conversion/converters/impl/plugins/interpolate_plugin.h
@@ -25,14 +25,14 @@ namespace plugins {
 
 class InterpolatePlugin : public nvinfer1::IPluginV2DynamicExt {
 private:
-    at::TensorOptions tensor_options;
-    DataType dtype;
+    at::TensorOptions tensor_options_;
+    DataType dtype_;
 
-    std::vector<int64_t> in_shape;
-    std::vector<int64_t> out_shape;
-    std::vector<int64_t> size;
-    std::string mode;
-    bool align_corners;
+    std::vector<int64_t> in_shape_;
+    std::vector<int64_t> out_shape_;
+    std::vector<int64_t> size_;
+    std::string mode_;
+    bool align_corners_;
 
 protected:
     // To prevent compiler warnings
@@ -46,7 +46,7 @@ protected:
 
 public:
     InterpolatePlugin(std::vector<int64_t> in_shape, std::vector<int64_t> out_shape, std::vector<int64_t> size, std::string mode, bool align_corners);
-    
+
     InterpolatePlugin(const char *data, size_t length);
 
     InterpolatePlugin() = delete;
@@ -91,14 +91,14 @@ public:
 
     size_t getWorkspaceSize(const nvinfer1::PluginTensorDesc* inputs, int nbInputs, const nvinfer1::PluginTensorDesc* outputs, int nbOutputs) const override;
 
-    int enqueue(const nvinfer1::PluginTensorDesc* inputDesc, const nvinfer1::PluginTensorDesc* outputDesc, const void *const *inputs, 
-                                                                                                           void *const *outputs, void *workspace, 
+    int enqueue(const nvinfer1::PluginTensorDesc* inputDesc, const nvinfer1::PluginTensorDesc* outputDesc, const void *const *inputs,
+                                                                                                           void *const *outputs, void *workspace,
                                                                                                            cudaStream_t stream) override;
 };
 
 class InterpolatePluginCreator : public nvinfer1::IPluginCreator {
 private:
-    std::string name;
+    std::string name_;
 
 public:
     InterpolatePluginCreator() = default;
@@ -106,7 +106,7 @@ public:
     const char* getPluginNamespace() const override;
 
     void setPluginNamespace(const char* libNamespace) override {};
-    
+
     const char* getPluginName() const override;
 
     const char* getPluginVersion() const override;

--- a/core/conversion/converters/impl/pooling.cpp
+++ b/core/conversion/converters/impl/pooling.cpp
@@ -279,7 +279,11 @@ auto pooling_registrations TRTORCH_UNUSED = RegisterNodeConversionPatterns()
             auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
 
             if (ctx->input_is_dynamic) {
+#if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1)
+                LOG_WARNING("Adaptive pooling layer will be run through ATen, via not TensorRT, performace will be lower than expected. Consider switching either to static input shape or moving to non adaptive pooling if this is an issue");
+#else
                 LOG_WARNING("Adaptive pooling layer will be run through ATen (on CPU), via not TensorRT, performace will suffer. Consider switching either to static input shape or moving to non adaptive pooling");
+#endif
 
                 auto out_shape = in_shape;
                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));

--- a/core/conversion/converters/impl/pooling.cpp
+++ b/core/conversion/converters/impl/pooling.cpp
@@ -277,9 +277,9 @@ auto pooling_registrations TRTORCH_UNUSED = RegisterNodeConversionPatterns()
 
             //auto out_size = args[1].IValue()->toIntList();
             auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
-            
+
             if (ctx->input_is_dynamic) {
-                LOG_WARNING("Pooling layer will be run through ATen, not TensorRT. Performance may differ.");
+                LOG_WARNING("Adaptive pooling layer will be run through ATen (on CPU), via not TensorRT, performace will suffer. Consider switching either to static input shape or moving to non adaptive pooling");
 
                 auto out_shape = in_shape;
                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
@@ -319,7 +319,7 @@ auto pooling_registrations TRTORCH_UNUSED = RegisterNodeConversionPatterns()
 
                 LOG_DEBUG("Output tensor shape: " << out_tensor->getDimensions());
             }
-            
+
             return true;
         }
     });

--- a/tests/modules/hub.py
+++ b/tests/modules/hub.py
@@ -79,18 +79,18 @@ for n, m in models.items():
         script_model = torch.jit.script(m["model"])
         torch.jit.save(script_model, n + '_scripted.jit.pt')
 
-# Sample Interpolation Model (align_corners=False, for Testing Interpolate Plugin specifically)
-class Interpolate(nn.Module):
+# Sample Pool Model (for testing plugin serialization)
+class Pool(nn.Module):
     def __init__(self):
-        super(Interpolate, self).__init__()
+        super(Pool, self).__init__()
 
     def forward(self, x):
-        return F.interpolate(x, size=(10, 10, 10), align_corners=False, mode="trilinear")
+        return F.adaptive_avg_pool2d(x, (5, 5))
 
-model = Interpolate().eval().cuda()
-x = torch.ones([1, 3, 5, 5, 5]).cuda()
+model = Pool().eval().cuda()
+x = torch.ones([1, 3, 10, 10]).cuda()
 
 trace_model = torch.jit.trace(model, x)
-torch.jit.save(trace_model, "interpolate_traced.jit.pt")
+torch.jit.save(trace_model, "pooling_traced.jit.pt")
 
 

--- a/tests/modules/test_serialization.cpp
+++ b/tests/modules/test_serialization.cpp
@@ -1,5 +1,23 @@
 #include "module_test.h"
 
+std::vector<trtorch::ExtraInfo::InputRange> toInputRangesDynamic(std::vector<std::vector<int64_t>> opts) {
+    std::vector<trtorch::ExtraInfo::InputRange> a;
+
+    for (auto opt : opts) {
+        std::vector<int64_t> min_range(opt);
+        std::vector<int64_t> max_range(opt);
+
+        min_range[3] = ceil(opt[3]/2.0);
+        max_range[3] = 2*opt[3];
+        min_range[2] = ceil(opt[2]/2.0);
+        max_range[2] = 2*opt[2];
+
+        a.push_back(trtorch::ExtraInfo::InputRange(min_range, opt, max_range));
+    }
+
+    return std::move(a);
+}
+
 TEST_P(ModuleTests, SerializedModuleIsStillCorrect) {
     std::vector<torch::jit::IValue> post_serialized_inputs_ivalues;
     std::vector<torch::jit::IValue> pre_serialized_inputs_ivalues;
@@ -26,11 +44,37 @@ TEST_P(ModuleTests, SerializedModuleIsStillCorrect) {
     }
 }
 
+TEST_P(ModuleTests, SerializedDynamicModuleIsStillCorrect) {
+    std::vector<torch::jit::IValue> post_serialized_inputs_ivalues;
+    std::vector<torch::jit::IValue> pre_serialized_inputs_ivalues;
+    for (auto in_shape : input_shapes) {
+        auto in = at::randint(5, in_shape, {at::kCUDA});
+        post_serialized_inputs_ivalues.push_back(in.clone());
+        pre_serialized_inputs_ivalues.push_back(in.clone());
+    }
+
+    auto pre_serialized_mod = trtorch::CompileGraph(mod, toInputRangesDynamic(input_shapes));
+    torch::jit::IValue pre_serialized_results_ivalues = trtorch::tests::util::RunModuleForward(pre_serialized_mod, pre_serialized_inputs_ivalues);
+    std::vector<at::Tensor> pre_serialized_results;
+    pre_serialized_results.push_back(pre_serialized_results_ivalues.toTensor());
+
+    pre_serialized_mod.save("test_serialization_mod.ts");
+    auto post_serialized_mod = torch::jit::load("test_serialization_mod.ts");
+
+    torch::jit::IValue post_serialized_results_ivalues = trtorch::tests::util::RunModuleForward(post_serialized_mod, post_serialized_inputs_ivalues);
+    std::vector<at::Tensor> post_serialized_results;
+    post_serialized_results.push_back(post_serialized_results_ivalues.toTensor());
+
+    for (size_t i = 0; i < pre_serialized_results.size(); i++) {
+        ASSERT_TRUE(trtorch::tests::util::almostEqual(post_serialized_results[i], pre_serialized_results[i].reshape_as(post_serialized_results[i]), 2e-5));
+    }
+}
+
 
 INSTANTIATE_TEST_SUITE_P(CompiledModuleForwardIsCloseSuite,
                          ModuleTests,
                          testing::Values(
                             PathAndInSize({"tests/modules/resnet18_traced.jit.pt",
                                           {{1,3,224,224}}}),
-                            PathAndInSize({"tests/modules/interpolate_traced.jit.pt",
-                                          {{1,3,5,5,5}}})));
+                            PathAndInSize({"tests/modules/pooling_traced.jit.pt",
+                                          {{1,3,10,10}}})));


### PR DESCRIPTION
# Description

This PR fixes the interpolate plugin which was segfaulting in the enqueue method on Tensor creation in ATen. As a work around to fix the issue in master until a long term solution is found we have reduced the scope of the interpolate function to only handle the case of `aten::adaptive_avg_pool_2d`. Other cases are now handled via TensorRT. 

This PR also add support for dilated and group conv_transpose

Fixes #129  (partially)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
   - No API change but perf regression on adaptive_avg_pool_2d dynamic input 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas and hacks
- [X] I have made corresponding changes to the documentation and have regenerated the documentation (`make html` in docsrc)
- [X] I have added tests to verify my fix or my feature
- [X] New and existing unit tests pass locally with my changes