### PR TITLE
feat(//py): setup.py now searches for bazel executable

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -24,8 +24,27 @@ if "--use-cxx11-abi" in sys.argv:
     sys.argv.remove("--use-cxx11-abi")
     CXX11_ABI = True
 
+def which(program):
+    import os
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    return None
+
+BAZEL_EXE = which("bazel")
+
 def build_libtrtorch_pre_cxx11_abi(develop=True, use_dist_dir=True, cxx11_abi=False):
-    cmd = ["/usr/bin/bazel", "build"]
+    cmd = [BAZEL_EXE, "build"]
     cmd.append("//cpp/api/lib:libtrtorch.so")
     if develop:
         cmd.append("--compilation_mode=dbg")


### PR DESCRIPTION
Signed-off-by: Naren Dasan <naren@narendasan.com>
Signed-off-by: Naren Dasan <narens@nvidia.com>

# Description

Allows setup.py to search for bazel installation path

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation and have regenerated the documentation (`make html` in docsrc)
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes