### PR TITLE
Fix missing unistd.h on Windows

### DIFF
--- a/core/util/macros.h
+++ b/core/util/macros.h
@@ -25,6 +25,19 @@
 #define LOG_ERROR_OWN(l,s)           TRTORCH_LOG(l, core::util::logging::LogLevel::kERROR, s)
 #define LOG_INTERNAL_ERROR_OWN(l,s)  TRTORCH_LOG(l, core::util::logging::LogLevel::kINTERNAL_ERROR, s)
 
+#ifdef _MSC_VER
+
+#define EXPAND( x ) x
+
+#define LOG_GRAPH(...)          EXPAND(GET_MACRO(__VA_ARGS__, LOG_GRAPH_OWN, LOG_GRAPH_GLOBAL)(__VA_ARGS__))
+#define LOG_DEBUG(...)          EXPAND(GET_MACRO(__VA_ARGS__, LOG_DEBUG_OWN, LOG_DEBUG_GLOBAL)(__VA_ARGS__))
+#define LOG_INFO(...)           EXPAND(GET_MACRO(__VA_ARGS__, LOG_INFO_OWN, LOG_INFO_GLOBAL)(__VA_ARGS__))
+#define LOG_WARNING(...)        EXPAND(GET_MACRO(__VA_ARGS__, LOG_WARNING_OWN, LOG_WARNING_GLOBAL)(__VA_ARGS__))
+#define LOG_ERROR(...)          EXPAND(GET_MACRO(__VA_ARGS__, LOG_ERROR_OWN, LOG_ERROR_GLOBAL)(__VA_ARGS__))
+#define LOG_INTERNAL_ERROR(...) EXPAND(GET_MACRO(__VA_ARGS__, LOG_INTERNAL_ERROR_OWN, LOG_INTERNAL_ERROR_GLOBAL)(__VA_ARGS__))
+
+#else
+
 #define LOG_GRAPH(...)          GET_MACRO(__VA_ARGS__, LOG_GRAPH_OWN, LOG_GRAPH_GLOBAL)(__VA_ARGS__)
 #define LOG_DEBUG(...)          GET_MACRO(__VA_ARGS__, LOG_DEBUG_OWN, LOG_DEBUG_GLOBAL)(__VA_ARGS__)
 #define LOG_INFO(...)           GET_MACRO(__VA_ARGS__, LOG_INFO_OWN, LOG_INFO_GLOBAL)(__VA_ARGS__)
@@ -32,6 +45,7 @@
 #define LOG_ERROR(...)          GET_MACRO(__VA_ARGS__, LOG_ERROR_OWN, LOG_ERROR_GLOBAL)(__VA_ARGS__)
 #define LOG_INTERNAL_ERROR(...) GET_MACRO(__VA_ARGS__, LOG_INTERNAL_ERROR_OWN, LOG_INTERNAL_ERROR_GLOBAL)(__VA_ARGS__)
 
+#endif
 // ----------------------------------------------------------------------------
 // Error reporting macros
 // ----------------------------------------------------------------------------

--- a/cpp/api/include/trtorch/trtorch.h
+++ b/cpp/api/include/trtorch/trtorch.h
@@ -90,7 +90,7 @@ struct TRTORCH_API ExtraInfo {
      * This class is compatable with c10::DataTypes (but will check for TRT support)
      * so there should not be a reason that you need to use this type explictly.
      */
-    class DataType {
+    class TRTORCH_API DataType {
     public:
         /**
          * Underlying enum class to support the DataType Class

--- a/cpp/trtorchc/main.cpp
+++ b/cpp/trtorchc/main.cpp
@@ -1,12 +1,19 @@
 #include <iostream>
 #include <sstream>
 #include <stdlib.h>
-#include <unistd.h>
 
 #ifdef linux
 #include <linux/limits.h>
 #else
 #define PATH_MAX 260
+#endif
+
+#ifdef _WIN32
+#include <direct.h>
+#define getcwd _getcwd
+#define realpath(N,R) _fullpath((R),(N),PATH_MAX)
+#elif
+#include <unistd.h>
 #endif
 
 #include "NvInfer.h"

--- a/cpp/trtorchc/main.cpp
+++ b/cpp/trtorchc/main.cpp
@@ -8,11 +8,11 @@
 #define PATH_MAX 260
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32)
 #include <direct.h>
 #define getcwd _getcwd
 #define realpath(N,R) _fullpath((R),(N),PATH_MAX)
-#elif
+#else
 #include <unistd.h>
 #endif
 

--- a/third_party/cuda/BUILD
+++ b/third_party/cuda/BUILD
@@ -8,11 +8,21 @@ config_setting(
     ],
 )
 
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
 cc_library(
     name = "cudart",
     srcs = select({
         ":aarch64_linux": [
             "targets/aarch64-linux/lib/libcudart.so",
+        ],
+        ":windows": [
+            "lib/x64/cudart.lib",
         ],
         "//conditions:default": [
             "targets/x86_64-linux/lib/libcudart.so",
@@ -32,6 +42,9 @@ cc_library(
         ":aarch64_linux": [
             "targets/aarch64-linux/lib/libnvToolsExt.so.1",
         ],
+        ":windows": [
+            "bin/nvToolsExt64_1.dll",
+        ],
         "//conditions:default": [
             "targets/x86_64-linux/lib/libnvToolsExt.so.1",
         ],
@@ -44,6 +57,9 @@ cc_library(
         ":aarch64_linux": glob([
             "targets/aarch64-linux/lib/**/lib*.so",
         ]),
+        ":windows": [
+            "bin/*.dll",
+        ],
         "//conditions:default": glob([
             "targets/x86_64-linux/lib/**/lib*.so",
         ]),
@@ -59,9 +75,17 @@ cc_library(
 
 cc_library(
     name = "cublas",
-    srcs = glob([
-        "lib/**/*libcublas.so",
-    ]),
+    srcs = select({
+        ":aarch64_linux": glob([
+            "lib/**/*libcublas.so",
+        ]),
+        ":windows": glob([
+            "lib/x64/cublas.lib",
+        ]),
+        "//conditions:default": glob([
+            "lib/**/*libcublas.so",
+        ]),
+    }),
     hdrs = glob([
         "include/**/*cublas*.h",
         "include/**/*.hpp",

--- a/third_party/cudnn/local/BUILD
+++ b/third_party/cudnn/local/BUILD
@@ -8,6 +8,13 @@ config_setting(
     ],
 )
 
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
 cc_library(
     name = "cudnn_headers",
     hdrs = ["include/cudnn.h"] + glob(["include/cudnn+.h"]),
@@ -19,6 +26,7 @@ cc_import(
     name = "cudnn_lib",
     shared_library = select({
         ":aarch64_linux": "lib/aarch64-linux-gnu/libcudnn.so",
+        ":windows": glob(["bin/cudnn64_*.dll"])[0],
         "//conditions:default": "lib/x86_64-linux-gnu/libcudnn.so",
     }),
     visibility = ["//visibility:private"],

--- a/third_party/libtorch/BUILD
+++ b/third_party/libtorch/BUILD
@@ -1,5 +1,12 @@
 package(default_visibility = ["//visibility:public"])
 
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
 cc_library(
     name = "libtorch",
     deps = [
@@ -18,12 +25,20 @@ cc_library(
     ) + glob([
         'include/torch/csrc/api/include/**/*.h'
     ]),
-    srcs = [
-        'lib/libtorch.so',
-        'lib/libtorch_cuda.so',
-        'lib/libtorch_cpu.so',
-        'lib/libtorch_global_deps.so',
-    ],
+    srcs = select({
+        ":windows": [
+            'lib/torch.lib',
+            'lib/torch_cuda.lib',
+            'lib/torch_cpu.lib',
+            'lib/torch_global_deps.dll',
+        ],
+        "//conditions:default": [
+            'lib/libtorch.so',
+            'lib/libtorch_cuda.so',
+            'lib/libtorch_cpu.so',
+            'lib/libtorch_global_deps.so',
+        ],
+    }),
     deps = [
         ":ATen",
         ":c10_cuda",
@@ -39,7 +54,10 @@ cc_library(
     hdrs = glob([
         'include/c10/**/*.h'
     ]),
-    srcs = ["lib/libc10_cuda.so"],
+    srcs = select({
+        ":windows": ["lib/c10_cuda.lib"],
+        "//conditions:default": ["lib/libc10_cuda.so"],
+    }),
     strip_include_prefix = "include",
     deps = [
         ":c10"
@@ -51,7 +69,10 @@ cc_library(
     hdrs = glob([
         'include/c10/**/*.h'
     ]),
-    srcs = ["lib/libc10.so"],
+    srcs = select({
+        ":windows": ["lib/c10.lib"],
+        "//conditions:default": ["lib/libc10.so"],
+    }),
     strip_include_prefix = "include",
 )
 
@@ -68,11 +89,18 @@ cc_library(
     hdrs = glob([
         'include/caffe2/**/*.h'
     ]),
-    srcs = [
-        'lib/libcaffe2_nvrtc.so',
-        'lib/libcaffe2_detectron_ops_gpu.so',
-        'lib/libcaffe2_observers.so',
-        'lib/libcaffe2_module_test_dynamic.so'
-    ],
+    srcs = select({
+        ":windows": [
+            'lib/caffe2_nvrtc.lib',
+            'lib/caffe2_detectron_ops_gpu.lib',
+            'lib/caffe2_module_test_dynamic.lib'
+        ],
+        "//conditions:default": [
+            'lib/libcaffe2_nvrtc.so',
+            'lib/libcaffe2_detectron_ops_gpu.so',
+            'lib/libcaffe2_observers.so',
+            'lib/libcaffe2_module_test_dynamic.so'
+        ],
+    }),
     strip_include_prefix = "include",
 )

--- a/third_party/tensorrt/local/BUILD
+++ b/third_party/tensorrt/local/BUILD
@@ -112,7 +112,7 @@ cc_library(
             "include/NvOnnxParserRuntime.h",
             "include/NvOnnxConfig.h",
             "include/NvUffParser.h"
-        ]
+        ],
         "//conditions:default": [
             "include/x86_64-linux-gnu/NvCaffeParser.h",
             "include/x86_64-linux-gnu/NvOnnxParser.h",
@@ -163,7 +163,7 @@ cc_library(
             "include/NvOnnxParser.h",
             "include/NvOnnxParserRuntime.h",
             "include/NvOnnxConfig.h"
-        ]
+        ],
         "//conditions:default": [
             "include/x86_64-linux-gnu/NvOnnxParser.h",
             "include/x86_64-linux-gnu/NvOnnxParserRuntime.h",
@@ -208,7 +208,7 @@ cc_library(
         ],
         ":windows": [
             "include/NvOnnxParserRuntime.h",
-        ]
+        ],
         "//conditions:default": [
             "include/x86_64-linux-gnu/NvOnnxParserRuntime.h",
         ]
@@ -251,7 +251,7 @@ cc_library(
         ],
         ":windows": [
             "include/NvCaffeParser.h",
-        ]
+        ],
         "//conditions:default": [
             "include/x86_64-linux-gnu/NvCaffeParser.h",
         ]
@@ -290,7 +290,7 @@ cc_library(
     name = "nvinferplugin_headers",
     hdrs = select({
         ":aarch64_linux": glob(["include/aarch64-linux-gnu/NvInferPlugin*.h"]),
-        ":windows": glob(["include/NvInferPlugin*.h"])
+        ":windows": glob(["include/NvInferPlugin*.h"]),
         "//conditions:default": glob(["include/x86_64-linux-gnu/NvInferPlugin*.h"])
     }),
     includes = select({

--- a/third_party/tensorrt/local/BUILD
+++ b/third_party/tensorrt/local/BUILD
@@ -8,6 +8,13 @@ config_setting(
     ],
 )
 
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
 cc_library(
     name = "nvinfer_headers",
     hdrs = select({
@@ -20,6 +27,17 @@ cc_library(
             exclude = [
                 "include/aarch64-linux-gnu/NvInferPlugin.h",
                 "include/aarch64-linux-gnu/NvInferPluginUtils.h",
+            ],
+        ),
+        ":windows": [
+            "include/NvUtils.h",
+        ] + glob(
+            [
+                "include/NvInfer*.h",
+            ],
+            exclude = [
+                "include/NvInferPlugin.h",
+                "include/NvInferPluginUtils.h",
             ],
         ),
         "//conditions:default": [
@@ -36,6 +54,7 @@ cc_library(
     }),
     includes = select({
         ":aarch64_linux": ["include/aarch64-linux-gnu"],
+        ":windows": ["include/"],
         "//conditions:default": ["include/x86_64-linux-gnu/"],
     }),
     visibility = ["//visibility:private"],
@@ -45,6 +64,7 @@ cc_import(
     name = "nvinfer_lib",
     shared_library = select({
         ":aarch64_linux": "lib/aarch64-linux-gnu/libnvinfer.so",
+        ":windows": "lib/nvinfer.dll",
         "//conditions:default": "lib/x86_64-linux-gnu/libnvinfer.so",
     }),
     visibility = ["//visibility:private"],
@@ -52,6 +72,7 @@ cc_import(
 
 cc_library(
     name = "nvinfer",
+    srcs = select({ ":windows": [ "lib/nvinfer.lib" ] }),
     deps = [
         "nvinfer_headers",
         "nvinfer_lib",
@@ -68,6 +89,7 @@ cc_import(
     name = "nvparsers_lib",
     shared_library = select({
         ":aarch64_linux": "lib/aarch64-linux-gnu/libnvparsers.so",
+        ":windows": "lib/nvparsers.dll",
         "//conditions:default": "lib/x86_64-linux-gnu/libnvparsers.so",
     }),
     visibility = ["//visibility:private"],
@@ -84,6 +106,13 @@ cc_library(
             "include/aarch64-linux-gnu/NvOnnxConfig.h",
             "include/aarch64-linux-gnu/NvUffParser.h"
         ],
+        ":windows": [
+            "include/NvCaffeParser.h",
+            "include/NvOnnxParser.h",
+            "include/NvOnnxParserRuntime.h",
+            "include/NvOnnxConfig.h",
+            "include/NvUffParser.h"
+        ]
         "//conditions:default": [
             "include/x86_64-linux-gnu/NvCaffeParser.h",
             "include/x86_64-linux-gnu/NvOnnxParser.h",
@@ -94,6 +123,7 @@ cc_library(
     }),
     includes = select({
         ":aarch64_linux": ["include/aarch64-linux-gnu"],
+        ":windows": ["include/"],
         "//conditions:default": ["include/x86_64-linux-gnu/"],
     }),
     visibility = ["//visibility:private"],
@@ -115,6 +145,7 @@ cc_import(
     name = "nvonnxparser_lib",
     shared_library = select({
         ":aarch64_linux": "lib/aarch64-linux-gnu/libnvonnxparser.so",
+        ":windows": "lib/nvonnxparser.dll",
         "//conditions:default": "lib/x86_64-linux-gnu/libnvonnxparser.so",
     }),
     visibility = ["//visibility:private"],
@@ -128,6 +159,11 @@ cc_library(
             "include/aarch64-linux-gnu/NvOnnxParserRuntime.h",
             "include/aarch64-linux-gnu/NvOnnxConfig.h"
         ],
+        ":windows": [
+            "include/NvOnnxParser.h",
+            "include/NvOnnxParserRuntime.h",
+            "include/NvOnnxConfig.h"
+        ]
         "//conditions:default": [
             "include/x86_64-linux-gnu/NvOnnxParser.h",
             "include/x86_64-linux-gnu/NvOnnxParserRuntime.h",
@@ -136,6 +172,7 @@ cc_library(
     }),
     includes = select({
         ":aarch64_linux": ["include/aarch64-linux-gnu"],
+        ":windows": ["include/"],
         "//conditions:default": ["include/x86_64-linux-gnu/"],
     }),
     visibility = ["//visibility:private"],
@@ -157,6 +194,7 @@ cc_import(
     name = "nvonnxparser_runtime_lib",
     shared_library = select({
         ":aarch64_linux": "lib/x86_64-linux-gnu/libnvonnxparser_runtime.so",
+        ":windows": "lib/nvonnxparser_runtime.dll",
         "//conditions:default": "lib/x86_64-linux-gnu/libnvonnxparser_runtime.so",
     }),
     visibility = ["//visibility:public"],
@@ -168,12 +206,16 @@ cc_library(
         ":aarch64_linux": [
             "include/aarch64-linux-gnu/NvOnnxParserRuntime.h",
         ],
+        ":windows": [
+            "include/NvOnnxParserRuntime.h",
+        ]
         "//conditions:default": [
             "include/x86_64-linux-gnu/NvOnnxParserRuntime.h",
         ]
     }),
     includes = select({
         ":aarch64_linux": ["include/aarch64-linux-gnu"],
+        ":windows": ["include/"],
         "//conditions:default": ["include/x86_64-linux-gnu/"],
     }),
     visibility = ["//visibility:private"],
@@ -195,6 +237,7 @@ cc_import(
     name = "nvcaffeparser_lib",
     shared_library = select({
         ":aarch64_linux": "lib/aarch64-linux-gnu/libnvcaffe_parsers.so",
+        ":windows": "lib/nvcaffe_parsers.dll",
         "//conditions:default": "lib/x86_64-linux-gnu/libnvcaffe_parsers.so",
     }),
     visibility = ["//visibility:private"],
@@ -206,12 +249,16 @@ cc_library(
         ":aarch64_linux": [
             "include/aarch64-linux-gnu/NvCaffeParser.h",
         ],
+        ":windows": [
+            "include/NvCaffeParser.h",
+        ]
         "//conditions:default": [
             "include/x86_64-linux-gnu/NvCaffeParser.h",
         ]
     }),
     includes = select({
         ":aarch64_linux": ["include/aarch64-linux-gnu"],
+        ":windows": ["include/"],
         "//conditions:default": ["include/x86_64-linux-gnu/"],
     }),
     visibility = ["//visibility:private"],
@@ -233,6 +280,7 @@ cc_import(
     name = "nvinferplugin_lib",
     shared_library = select({
         ":aarch64_linux": "lib/x86_64-linux-gnu/libnvinfer_plugin.so",
+        ":windows": "lib/nvinfer_plugin.dll",
         "//conditions:default": "lib/x86_64-linux-gnu/libnvinfer_plugin.so",
     }),
     visibility = ["//visibility:private"],
@@ -242,10 +290,12 @@ cc_library(
     name = "nvinferplugin_headers",
     hdrs = select({
         ":aarch64_linux": glob(["include/aarch64-linux-gnu/NvInferPlugin*.h"]),
+        ":windows": glob(["include/NvInferPlugin*.h"])
         "//conditions:default": glob(["include/x86_64-linux-gnu/NvInferPlugin*.h"])
     }),
     includes = select({
         ":aarch64_linux": ["include/aarch64-linux-gnu"],
+        ":windows": ["include/"],
         "//conditions:default": ["include/x86_64-linux-gnu/"],
     }),
     visibility = ["//visibility:private"],


### PR DESCRIPTION
# Description

As part of Windows compatibility, a simple replacement for the two unistd functions is provided.
Also add in a missing export that is necessary on Windows.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation and have regenerated the documentation (`make html` in docsrc)
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes