### PR TITLE
Use TensorRT 20.03 as base container for builds

### DIFF
--- a/notebooks/Dockerfile.notebook
+++ b/notebooks/Dockerfile.notebook
@@ -1,6 +1,5 @@
-FROM nvcr.io/nvidia/pytorch:20.03-py3
+FROM nvcr.io/nvidia/tensorrt:20.03-py3
 
-RUN apt update && apt install curl gnupg
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 
@@ -10,6 +9,7 @@ RUN ln -s /usr/bin/bazel-3.3.1 /usr/bin/bazel
 RUN pip install pillow==4.3.0
 RUN pip install torch==1.5.1
 RUN pip install torchvision==0.6.1
+RUN pip install notebook
 
 COPY . /workspace/TRTorch
 RUN rm /workspace/TRTorch/WORKSPACE
@@ -19,6 +19,12 @@ WORKDIR /workspace/TRTorch
 RUN bazel build //:libtrtorch --compilation_mode opt
 
 WORKDIR /workspace/TRTorch/py
+
+# Locale is not set by default
+RUN apt update && apt install -y locales && locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 RUN python3 setup.py install
 
 WORKDIR /workspace/TRTorch/notebooks


### PR DESCRIPTION
# Description
- Change replaces pytorch 20.03 with tensorrt 20.03
as base container for trtorch builds.

- Adds locale setting as no locale was set by default leading to build failure.

Signed-off-by: Shashank Verma <shashank3959@gmail.com>

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation and have regenerated the documentation (`make html` in docsrc)
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes