### PR TITLE
fix(Windows)!: Fix dependency resolution for local builds

### DIFF
--- a/third_party/cudnn/local/BUILD
+++ b/third_party/cudnn/local/BUILD
@@ -26,7 +26,7 @@ cc_import(
     name = "cudnn_lib",
     shared_library = select({
         ":aarch64_linux": "lib/aarch64-linux-gnu/libcudnn.so",
-        ":windows": glob(["bin/cudnn64_*.dll"])[0],
+        ":windows": "bin/cudnn64_7.dll", #Need to configure specific version for windows
         "//conditions:default": "lib/x86_64-linux-gnu/libcudnn.so",
     }),
     visibility = ["//visibility:private"],

--- a/third_party/tensorrt/local/BUILD
+++ b/third_party/tensorrt/local/BUILD
@@ -72,7 +72,6 @@ cc_import(
 
 cc_library(
     name = "nvinfer",
-    srcs = select({ ":windows": [ "lib/nvinfer.lib" ] }),
     deps = [
         "nvinfer_headers",
         "nvinfer_lib",


### PR DESCRIPTION
BREAKING CHANGE: Users on Windows trying to use cuDNN 8 must manually
configure third_party/cudnn/local/BUILD to use cuDNN 8.

Signed-off-by: Naren Dasan <naren@narendasan.com>
Signed-off-by: Naren Dasan <narens@nvidia.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation and have regenerated the documentation (`make html` in docsrc)
- [ ] I have added tests to verify my fix or my feature
- [X] New and existing unit tests pass locally with my changes