### PR TITLE
refactor(windows): Windows specific packaging rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,12 @@
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
+config_setting(
+    name = "windows",
+    constraint_values = [
+        "@platforms//os:windows",
+    ],
+)
+
 pkg_tar(
     name = "include_core",
     package_dir = "include/trtorch",
@@ -31,9 +38,10 @@ pkg_tar(
 pkg_tar(
     name = "lib",
     package_dir = "lib/",
-    srcs = [
-        "//cpp/api/lib:libtrtorch.so",
-    ],
+    srcs = select({
+        ":windows": ["//cpp/api/lib:trtorch.dll"],
+        "//conditions:default": ["//cpp/api/lib:libtrtorch.so"],
+    }),
     mode = "0755",
 )
 
@@ -57,8 +65,10 @@ pkg_tar(
     ],
     deps = [
         ":lib",
-        ":bin",
         ":include",
         ":include_core",
-    ],
+    ] + select({
+        ":windows": [],
+        "//conditions:default": [":bin"],
+    }),
 )

--- a/cpp/api/lib/BUILD
+++ b/cpp/api/lib/BUILD
@@ -9,3 +9,13 @@ cc_binary(
     linkstatic = True,
     linkshared = True
 )
+
+cc_binary(
+    name = "trtorch.dll",
+    srcs = [],
+    deps = [
+        "//cpp/api:trtorch"
+    ],
+    linkstatic = True,
+    linkshared = True
+)


### PR DESCRIPTION
# Description

Now the generated tarball will contain trtorch.dll instead of a misnamed
file and will not include trtorchc (since we don't want to distribute
all the associated libraries as well)

Signed-off-by: Naren Dasan <naren@narendasan.com>

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes