### PR TITLE
Add power layer conversion support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ then you have two options.
 1. You need to download the tarball distributions of TensorRT and cuDNN from the NVIDIA website.
     - https://developer.nvidia.com/cudnn
     - https://developer.nvidia.com/tensorrt
-2. Place these files in a directory (the directories `third_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]` exist for this purpose)
+2. Place these files in a directory (the directories `third_party/dist_dir/[x86_64-linux-gnu | aarch64-linux-gnu]` exist for this purpose)
 3. Compile using:
 ``` shell
-bazel build //:libtrtorch --compilation_mode opt --distdir third_party/distdir/[x86_64-linux-gnu | aarch64-linux-gnu]
+bazel build //:libtrtorch --compilation_mode opt --distdir third_party/dist_dir/[x86_64-linux-gnu | aarch64-linux-gnu]
 ```
 
 #### 2. Building using locally installed cuDNN & TensorRT
@@ -175,7 +175,7 @@ bazel build //:libtrtorch --compilation_mode=dbg
 
 ### Native compilation on NVIDIA Jetson AGX
 ``` shell
-bazel build //:libtrtorch --distdir third_party/distdir/aarch64-linux-gnu
+bazel build //:libtrtorch --distdir third_party/dist_dir/aarch64-linux-gnu
 ```
 > Note: Please refer [installation](docs/tutorials/installation.html) instructions for Pre-requisites
 

--- a/py/README.md
+++ b/py/README.md
@@ -22,7 +22,7 @@ traced_model = torch.jit.trace(model, [data])
 
 # Compile module
 compiled_trt_model = trtorch.compile(model, {
-    "input_shape": [data.shape],
+    "input_shapes": [data.shape],
     "op_precision": torch.half, # Run in FP16
 })
 

--- a/tests/core/converters/test_element_wise.cpp
+++ b/tests/core/converters/test_element_wise.cpp
@@ -4,23 +4,30 @@
 #include "tests/util/util.h"
 #include "core/compiler.h"
 
-void pointwise_test_helper(std::string graph_ir) {
+void pointwise_test_helper(std::string graph_ir, bool singleInput) {
     auto g = std::make_shared<torch::jit::Graph>();
     torch::jit::parseIR(graph_ir, &*g);
-
-    auto in0 = at::randint(1, 5, {5}, {at::kCUDA});
-    auto in1 = at::randint(1, 5, {5}, {at::kCUDA});
+    
+    // singleInput case is enabled when elementwise operation is performed 
+    // with an input and a constant embedded in graph
+    std::vector<at::Tensor> torch_inputs;
+    torch_inputs.push_back(at::randint(1, 5, {5}, {at::kCUDA}));
+    if (!singleInput) {
+        torch_inputs.push_back(at::randint(1, 5, {5}, {at::kCUDA}));
+    }
     auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-    auto jit_results = trtorch::tests::util::RunGraph(g, params, {in0, in1});
+    auto jit_results = trtorch::tests::util::RunGraph(g, params, torch_inputs);
+    
+    std::vector<at::Tensor> trt_inputs;
+    for (auto in : torch_inputs) {
+        trt_inputs.push_back(at::clone(in));
+    }
 
-    in0 = at::clone(in0);
-    in1 = at::clone(in1);
     params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-    auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {in0, in1});
+    auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, trt_inputs);
 
     ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt_results[0], 2e-6));
 }
-
 
 
 TEST(Converters, ATenAddConvertsCorrectly) {
@@ -29,7 +36,7 @@ TEST(Converters, ATenAddConvertsCorrectly) {
         %2 : int = prim::Constant[value=1]()
         %3 : Tensor = aten::add(%0, %1, %2)
         return (%3))IR";
-    pointwise_test_helper(graph);
+    pointwise_test_helper(graph, false);
 }
 
 
@@ -39,7 +46,7 @@ TEST(Converters, ATenAddConvertsCorrectly) {
 //         %2 : int = prim::Constant[value=2]()
 //         %3 : Tensor = aten::add(%0, %1, %2)
 //         return (%3))IR";
-//     pointwise_test_helper(graph);
+//     pointwise_test_helper(graph, false);
 // }
 
 TEST(Converters, ATenSubConvertsCorrectly) {
@@ -48,7 +55,7 @@ TEST(Converters, ATenSubConvertsCorrectly) {
         %2 : int = prim::Constant[value=1]()
         %3 : Tensor = aten::sub(%0, %1, %2)
         return (%3))IR";
-    pointwise_test_helper(graph);
+    pointwise_test_helper(graph, false);
 }
 
 // TEST(Converters, ATenSubWithScaleConvertsCorrectly) {
@@ -57,7 +64,7 @@ TEST(Converters, ATenSubConvertsCorrectly) {
 //         %2 : float = prim::Constant[value=0.5]()
 //         %3 : Tensor = aten::add(%0, %1, %2)
 //         return (%3))IR";
-//     pointwise_test_helper(graph);
+//     pointwise_test_helper(graph, false);
 // }
 
 TEST(Converters, ATenMulConvertsCorrectly) {
@@ -65,7 +72,7 @@ TEST(Converters, ATenMulConvertsCorrectly) {
       graph(%0 : Tensor, %1 : Tensor):
         %2 : Tensor = aten::mul(%0, %1)
         return (%2))IR";
-    pointwise_test_helper(graph);
+    pointwise_test_helper(graph, false);
 }
 
 TEST(Converters, ATenDivConvertsCorrectly) {
@@ -73,5 +80,22 @@ TEST(Converters, ATenDivConvertsCorrectly) {
       graph(%0 : Tensor, %1 : Tensor):
         %2 : Tensor = aten::div(%0, %1)
         return (%2))IR";
-    pointwise_test_helper(graph);
+    pointwise_test_helper(graph, false);
+}
+
+TEST(Converters, ATenPowTensorConvertsCorrectly) {
+    const auto graph = R"IR(
+       graph(%x.1 : Tensor, %x2.1 : Tensor):
+          %3 : Tensor = aten::pow(%x.1, %x2.1)
+          return (%3))IR";
+    pointwise_test_helper(graph, false);
+}
+
+TEST(Converters, ATenPowScalarConvertsCorrectly) {
+    const auto graph = R"IR(
+        graph(%x.1 : Tensor):
+          %2 : int = prim::Constant[value=2]()
+          %3 : Tensor = aten::pow(%x.1, %2)
+          return (%3))IR";
+    pointwise_test_helper(graph, true);
 }


### PR DESCRIPTION
# Description

Add support for converting power layer in Pytorch (torch.pow). Request : [https://github.com/NVIDIA/TRTorch/issues/184](https://github.com/NVIDIA/TRTorch/issues/184)

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes