### PR TITLE
fix(//tests/accuracy): Fix int8 accuracy test for new PTQ api

### DIFF
--- a/tests/accuracy/test_int8_accuracy.cpp
+++ b/tests/accuracy/test_int8_accuracy.cpp
@@ -1,6 +1,7 @@
 #include "accuracy_test.h"
 #include "datasets/cifar10.h"
 #include "torch/torch.h"
+#include "trtorch/ptq.h"
 
 TEST_P(AccuracyTests, FP16AccuracyIsClose) {
     auto calibration_dataset = datasets::CIFAR10("tests/accuracy/datasets/data/cifar-10-batches-bin/", datasets::CIFAR10::Mode::kTest)


### PR DESCRIPTION
Signed-off-by: Naren Dasan <naren@narendasan.com>
Signed-off-by: Naren Dasan <narens@nvidia.com>

# Description

Fixing a missing include in the int8 test accuracy. 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas and hacks
- [X] I have made corresponding changes to the documentation
- [X] I have added tests to verify my fix or my feature
- [X] New and existing unit tests pass locally with my changes