### PR TITLE
feat(//cpp/api/lib): New runtime only library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -40,7 +40,10 @@ pkg_tar(
     package_dir = "lib/",
     srcs = select({
         ":windows": ["//cpp/api/lib:trtorch.dll"],
-        "//conditions:default": ["//cpp/api/lib:libtrtorch.so"],
+        "//conditions:default": [
+            "//cpp/api/lib:libtrtorch.so",
+            "//cpp/api/lib:libtrtorchrt.so",
+        ],
     }),
     mode = "0755",
 )

--- a/cpp/api/lib/BUILD
+++ b/cpp/api/lib/BUILD
@@ -1,6 +1,16 @@
 package(default_visibility = ["//visibility:public"])
 
 cc_binary(
+    name = "libtrtorchrt.so",
+    srcs = [],
+    deps = [
+        "//core/runtime:runtime"
+    ],
+    linkstatic = True,
+    linkshared = True
+)
+
+cc_binary(
     name = "libtrtorch.so",
     srcs = [],
     deps = [

--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -26,6 +26,7 @@ Getting Started
 * :ref:`ptq`
 * :ref:`trtorchc`
 * :ref:`use_from_pytorch`
+* :ref:`runtime`
 
 
 .. toctree::
@@ -38,6 +39,7 @@ Getting Started
    tutorials/ptq
    tutorials/trtorchc
    tutorials/use_from_pytorch
+   tutorials/runtime
    _notebooks/lenet
 
 .. toctree::

--- a/docsrc/tutorials/runtime.rst
+++ b/docsrc/tutorials/runtime.rst
@@ -1,0 +1,25 @@
+.. _runtime:
+
+Deploying TRTorch Programs
+===========================
+
+After compiling and saving TRTorch programs there is no longer a strict dependency on the full
+TRTorch library. All that is required to run a compiled program is the runtime. There are therfore a couple
+options to deploy your programs other than shipping the full trtorch compiler with your applications.
+
+TRTorch package / libtrtorch.so
+---------------------------------
+
+Once a program is compiled, you run it using the standard PyTorch APIs. All that is required is that the package
+must be imported in python or linked in C++.
+
+Runtime Library
+-----------------
+
+Distributed with the C++ distribution is ``libtrtorchrt.so``. This library only contains the components
+necessary to run TRTorch programs. Instead of linking ``libtrtorch.so`` or importing ``trtorch`` you can
+link ``libtrtorchrt.so`` in your deployment programs or use ``DL_OPEN`` or ``LD_PRELOAD``. For python
+you can load the runtime with ``torch.ops.load_library("libtrtorchrt.so")``. You can then continue to use
+programs just as you would otherwise via PyTorch API.
+
+.. note:: If you are using the standard distribution of PyTorch in Python on x86, likely you will need the pre-cxx11-abi variant of ``libtrtorchrt.so``, check :ref:`Installation` documentation for more details.


### PR DESCRIPTION
# Description

Users now can simply ship the runtime library with their compiled
trtorch programs instead of the full compiler. The runtime will load
into pytorch on DL_OPEN, LD_PRELOAD or torch.ops.load

Signed-off-by: Naren Dasan <naren@narendasan.com>
Signed-off-by: Naren Dasan <narens@nvidia.com>

Fixes #77 

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas and hacks
- [X] I have made corresponding changes to the documentation
- [X] I have added tests to verify my fix or my feature
- [X] New and existing unit tests pass locally with my changes