### PR TITLE
feat(//core/converters): Add support for aten::slice layer

### DIFF
--- a/core/conversion/converters/impl/select.cpp
+++ b/core/conversion/converters/impl/select.cpp
@@ -138,6 +138,40 @@ auto select_registrations TRTORCH_UNUSED =
                LOG_DEBUG("Output tensor shape: " << out->getDimensions());
 
                return true;
+             }})
+        .pattern(
+            {"aten::slice.Tensor(Tensor(a) self, int dim=0, int start=0, int end=9223372036854775807, int step=1) -> Tensor(a)",
+             [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
+               auto in = args[0].ITensor();
+               auto axis = args[1].unwrapToInt();
+               auto maxDim = static_cast<int64_t>(in->getDimensions().d[axis]);
+               // Handle case when given tensor index is negative
+               auto startIdx = args[2].unwrapToInt();
+               auto start = (startIdx < 0) ? (maxDim + startIdx) : startIdx;
+               // Bound the end index to input tensor dimensions at specified axis
+               auto endIdx = std::min(args[3].unwrapToInt(), maxDim);
+               auto end = (endIdx < 0) ? (maxDim + endIdx) : endIdx;
+               auto step = args[4].unwrapToInt();
+
+               // indices to be accessed need to be an at::Tensor
+               at::Tensor indices = torch::arange(start, end, step).to(torch::kI32);
+               auto weights = Weights(ctx, indices);
+
+               // IConstantLayer to convert indices from Weights to ITensor
+               auto const_layer = ctx->net->addConstant(weights.shape, weights.data);
+               TRTORCH_CHECK(const_layer, "Unable to create constant layer from node: " << *n);
+               auto const_out = const_layer->getOutput(0);
+
+               // IGatherLayer takes in input tensor, the indices, and the axis of input tensor to take indices from
+               auto gather_layer = ctx->net->addGather(*in, *const_out, axis);
+               TRTORCH_CHECK(gather_layer, "Unable to create gather layer from node: " << *n);
+               auto gather_out = gather_layer->getOutput(0);
+
+               auto out = ctx->AssociateValueAndTensor(n->outputs()[0], gather_out);
+
+               LOG_DEBUG("Slice layer output shape: " << out->getDimensions());
+
+               return true;
              }});
 
 } // namespace

--- a/tests/core/converters/test_select.cpp
+++ b/tests/core/converters/test_select.cpp
@@ -1,3 +1,4 @@
+#include <torch/torch.h>
 #include <string>
 #include "core/compiler.h"
 #include "gtest/gtest.h"
@@ -107,6 +108,98 @@ TEST(Converters, ATenEmbeddingConvertsCorrectly) {
   // Run TensorRT
   auto options_trt = torch::TensorOptions().device(torch::kCUDA, 0).dtype(torch::kI32);
   auto trt_in = at::tensor({0, 1, 2}, options_trt);
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
+  auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
+TEST(Converters, ATenSliceConvertsCorrectly) {
+  const auto graph = R"IR(
+        graph(%x.1 : Tensor):
+              %2 : int = prim::Constant[value=9223372036854775807]()
+              %3 : int = prim::Constant[value=2]()
+              %4 : int = prim::Constant[value=4]()
+              %5 : int = prim::Constant[value=1]()
+              %6 : int = prim::Constant[value=0]()
+              %7 : Tensor = aten::select(%x.1, %6, %6)
+              %8 : Tensor = aten::select(%7, %6, %5)
+              %9 : Tensor = aten::slice(%8, %6, %5, %4, %3)
+              %10 : Tensor = aten::slice(%9, %5, %6, %2, %5)
+              return (%10))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, &*g);
+
+  auto in = at::randint(1, 10, {1, 3, 5, 5}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
+  auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
+TEST(Converters, ATenSliceNegStartIndexConvertsCorrectly) {
+  const auto graph = R"IR(
+        graph(%x.1 : Tensor):
+              %2 : int = prim::Constant[value=1]()
+              %3 : int = prim::Constant[value=9223372036854775807]()
+              %4 : int = prim::Constant[value=-2]()
+              %5 : int = prim::Constant[value=0]()
+              %6 : Tensor = aten::slice(%x.1, %5, %4, %3, %2)
+              %7 : Tensor = aten::slice(%6, %2, %5, %3, %2)
+              return (%7))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, &*g);
+
+  auto in = at::randint(1, 10, {6, 3}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
+  auto trt = trt_results[0].reshape(jit_results[0].sizes());
+
+  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
+TEST(Converters, ATenSliceNegEndIndexConvertsCorrectly) {
+  const auto graph = R"IR(
+        graph(%x.1 : Tensor):
+              %2 : int = prim::Constant[value=3]()
+              %3 : int = prim::Constant[value=9223372036854775807]()
+              %4 : int = prim::Constant[value=2]()
+              %5 : int = prim::Constant[value=-3]()
+              %6 : int = prim::Constant[value=1]()
+              %7 : int = prim::Constant[value=-2]()
+              %8 : int = prim::Constant[value=0]()
+              %9 : Tensor = aten::slice(%x.1, %8, %8, %7, %6)
+              %10 : Tensor = aten::slice(%9, %6, %8, %5, %6)
+              %11 : Tensor = aten::slice(%10, %4, %8, %3, %6)
+              %12 : Tensor = aten::slice(%11, %2, %8, %3, %6)
+              return (%12))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, &*g);
+
+  auto in = at::randint(1, 10, {6, 5, 3, 3}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
   auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
   auto trt = trt_results[0].reshape(jit_results[0].sizes());
 


### PR DESCRIPTION
# Description

Add conversion functionality for aten::slice layer. This is based on implicit Pytorch op. For example, the following snippet adds `aten::slice` in the graph.
```
class Slice(torch.nn.Module):
    def __init__(self):
        super(Slice, self).__init__()
        
    def forward(self, x): 
       return x[0, 1, 1:4:2, :]
```

Fixes (https://github.com/NVIDIA/TRTorch/issues/111)

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes