### PR TITLE
Explicit pattern matching for add + MM fusion

### DIFF
--- a/core/lowering/passes/fuse_addmm_branches.cpp
+++ b/core/lowering/passes/fuse_addmm_branches.cpp
@@ -44,21 +44,18 @@ struct AddMMBranchFusion {
     auto arm2 = n->blocks()[1];
 
     auto arm1_start = arm1->nodes().begin();
-    if ((*arm1_start)->kind().toQualString() != std::string("aten::addmm") &&
-        (*(++arm1_start))->kind() != prim::Return) {
-      // Make sure that block0 is solely just the aten::addmm op and the return
-      return false;
-    }
-
     auto arm2_start = arm2->nodes().begin();
-    if ((*arm2_start)->kind().toQualString() != std::string("aten::matmul") &&
+
+    if ((*arm1_start)->kind().toQualString() == std::string("aten::addmm") &&
+        (*(++arm1_start))->kind() == prim::Return &&
+        (*arm2_start)->kind().toQualString() == std::string("aten::matmul") &&
         (*(++arm2_start))->kind().toQualString() != std::string("aten::add_") &&
-        (*(++arm2_start))->kind() != prim::Return) {
-      // Make sure that block1 is solely the return
-      return false;
+        (*(++arm2_start))->kind() == prim::Return) {
+      // Make sure that block0 is solely just the aten::addmm op and block1 is matmul + add
+      return true;
     }
 
-    return true;
+    return false;
   }
 
   void findAddMMVariantsNodes(Block* b) {


### PR DESCRIPTION
# Description

Change the condition to find ADDMM variant nodes to be more explicit. The following issue happens even though it is not a add + matmul variant
```
 Found that node %scale_factor0.9 : float?, %size3.3 : int? = prim::If(%16230) # /opt/conda/lib/python3.6/site-packages/torch/nn/functional.py:2969:4
  block0():
     = prim::RaiseException(%16215) # /opt/conda/lib/python3.6/site-packages/torch/nn/functional.py:2970:8
    -> (%16220, %16221)
  block1():
    -> (%652, %size1.3)
 is an AddMM variants node (FuseAddMMBranches)
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes