### PR TITLE
fix(aten::max_pool2d): Supressing error due to not filling in stride in the default case

### DIFF
--- a/core/conversion/converters/impl/element_wise.cpp
+++ b/core/conversion/converters/impl/element_wise.cpp
@@ -124,7 +124,7 @@ auto element_wise_registrations TRTORCH_UNUSED =
                     auto self = args[0].ITensorOrFreeze(ctx);
                     auto otherScalar = args[1].unwrapToScalar().to<float>();
                     auto scalar = args[2].unwrapToScalar().to<float>();
-                    
+
                     // Calculate size of the input and broadcast other scalar to
                     // the same size
                     int volume = 1;
@@ -140,7 +140,7 @@ auto element_wise_registrations TRTORCH_UNUSED =
                     // output.
                     auto weights = converters::Weights(ctx, otherBlob);
                     auto otherTensor = ctx->net->addConstant(self->getDimensions(), weights.data)->getOutput(0);
-                    
+
                     auto add = add_elementwise(
                         ctx, nvinfer1::ElementWiseOperation::kSUM, self, otherTensor, util::node_info(n), scalar);
 

--- a/core/conversion/converters/impl/pooling.cpp
+++ b/core/conversion/converters/impl/pooling.cpp
@@ -30,6 +30,10 @@ bool MaxPoolingConverter(ConversionCtx* ctx, const torch::jit::Node* n, args& ar
   auto padding = util::toDims(args[3].unwrapToIntList());
   LOG_DEBUG("padding: " << padding);
   auto stride = util::toDims(args[2].unwrapToIntList());
+  if (args[2].unwrapToIntList().size() == 0) {
+    LOG_DEBUG("Stride not providied, using kernel_size as stride");
+    stride = util::toDims(args[1].unwrapToIntList());
+  }
   LOG_DEBUG("stride: " << stride);
 
   auto dilation = util::toDims(args[4].unwrapToIntList());
@@ -88,6 +92,10 @@ bool AvgPoolingConverter(ConversionCtx* ctx, const torch::jit::Node* n, args& ar
   auto padding = util::toDims(args[3].unwrapToIntList());
   LOG_DEBUG("padding: " << padding);
   auto stride = util::toDims(args[2].unwrapToIntList());
+  if (args[2].unwrapToIntList().size() == 0) {
+    LOG_DEBUG("Stride not providied, using kernel_size as stride");
+    stride = util::toDims(args[1].unwrapToIntList());
+  }
   LOG_DEBUG("stride: " << stride);
 
   bool ceil_mode = args[4].unwrapToBool();


### PR DESCRIPTION
Signed-off-by: Naren Dasan <naren@narendasan.com>
Signed-off-by: Naren Dasan <narens@nvidia.com>

# Description

Supressing error due to not filling in stride in the default case in pooling converters

Fixes #228 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project (You can use the linters)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas and hacks
- [X] I have made corresponding changes to the documentation
- [X] I have added tests to verify my fix or my feature
- [X] New and existing unit tests pass locally with my changes