### PR TITLE
Support bool datatype of input/output tensors

### DIFF
--- a/core/util/trt_util.cpp
+++ b/core/util/trt_util.cpp
@@ -229,6 +229,7 @@ const std::unordered_map<at::ScalarType, nvinfer1::DataType>& get_at_trt_type_ma
       {at::kHalf, nvinfer1::DataType::kHALF},
       {at::kInt, nvinfer1::DataType::kINT32},
       {at::kChar, nvinfer1::DataType::kINT8},
+      {at::kBool, nvinfer1::DataType::kBOOL},
   };
   return at_trt_type_map;
 }
@@ -239,6 +240,7 @@ const std::unordered_map<nvinfer1::DataType, at::ScalarType>& get_trt_at_type_ma
       {nvinfer1::DataType::kHALF, at::kHalf},
       {nvinfer1::DataType::kINT32, at::kInt},
       {nvinfer1::DataType::kINT8, at::kChar},
+      {nvinfer1::DataType::kBOOL, at::kBool},
   };
   return trt_at_type_map;
 }
@@ -249,7 +251,9 @@ const std::unordered_map<nvinfer1::DataType, at::ScalarType>& get_trt_aten_type_
 }
 
 at::ScalarType toATenDType(nvinfer1::DataType t) {
-  return get_trt_aten_type_map().at(t);
+  auto trt_aten_type_map = get_trt_aten_type_map();
+  TRTORCH_CHECK(trt_aten_type_map.find(t) != trt_aten_type_map.end(), "Unsupported TensorRT datatype");
+  return trt_aten_type_map.at(t);
 }
 
 const std::unordered_map<at::ScalarType, nvinfer1::DataType>& get_aten_trt_type_map() {
@@ -257,7 +261,9 @@ const std::unordered_map<at::ScalarType, nvinfer1::DataType>& get_aten_trt_type_
 }
 
 nvinfer1::DataType toTRTDataType(at::ScalarType t) {
-  return get_aten_trt_type_map().at(t);
+  auto aten_trt_type_map = get_aten_trt_type_map();
+  TRTORCH_CHECK(aten_trt_type_map.find(t) != aten_trt_type_map.end(), "Unsupported Aten datatype");
+  return aten_trt_type_map.at(t);
 }
 
 c10::optional<nvinfer1::DataType> toTRTDataType(caffe2::TypeMeta dtype) {

--- a/tests/util/util.cpp
+++ b/tests/util/util.cpp
@@ -17,7 +17,9 @@ bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs, flo
 
 bool almostEqual(const at::Tensor& a, const at::Tensor& b, float threshold) {
   LOG_DEBUG(a << std::endl << b << std::endl);
-  return checkRtol(a - b, {a, b}, threshold);
+  auto a_float = a.toType(at::kFloat);
+  auto b_float = b.toType(at::kFloat);
+  return checkRtol(a_float - b_float, {a_float, b_float}, threshold);
 }
 
 bool exactlyEqual(const at::Tensor& a, const at::Tensor& b) {


### PR DESCRIPTION
Signed-off-by: Dheeraj Peri <peri.dheeraj@gmail.com>

# Description

Support bool datatype for input/output tensors

Fixes  (https://github.com/NVIDIA/TRTorch/issues/242)
This change is required to support aten::gt, aten::le etc.. 
Testcases will be added by Vincent (author of https://github.com/NVIDIA/TRTorch/issues/242) when he submits PR for the converter ops. I verified with the testcase provided by him in the issue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes