### PR TITLE
Extending @uni19's work on support dynamic shape input and scale_factor in interpolate layer

### DIFF
--- a/core/conversion/converters/impl/interpolate.cpp
+++ b/core/conversion/converters/impl/interpolate.cpp
@@ -26,7 +26,7 @@ void create_plugin(
     std::vector<double> scales,
     std::string mode,
     bool align_corners,
-    bool use_scales=false) {
+    bool use_scales = false) {
   LOG_WARNING("Interpolation layer will be run through ATen, not TensorRT. Performance may be lower than expected");
 
   auto creator = new plugins::InterpolatePluginCreator();
@@ -50,38 +50,36 @@ void resize_layer_size(
     std::vector<float> scales,
     nvinfer1::ResizeMode mode,
     bool align_corners = false) {
-  TRTORCH_CHECK((out_shape.size() > 0) ^ (scales.size() > 0),  "only one of out_shape or scales should be defined");
+  TRTORCH_CHECK((out_shape.size() > 0) ^ (scales.size() > 0), "only one of out_shape or scales should be defined");
   auto resize_layer = ctx->net->addResize(*in);
   TRTORCH_CHECK(resize_layer, "Unable to create interpolation (resizing) layer from node" << *n);
 
   if (out_shape.size() > 0) {
-      auto th_dynamic_shape_mask = torch::zeros(out_shape.size(), torch::kInt32);
-      auto th_static_shape_mask = torch::zeros(out_shape.size(), torch::kInt32);
-      for (size_t idx = 0; idx < out_shape.size(); ++idx) {
-          if (out_shape[idx] == -1) {
-              th_dynamic_shape_mask[idx] = 1;
-          } else {
-              th_static_shape_mask[idx] = out_shape[idx];
-          }
+    auto th_dynamic_shape_mask = torch::zeros(out_shape.size(), torch::kInt32);
+    auto th_static_shape_mask = torch::zeros(out_shape.size(), torch::kInt32);
+    for (size_t idx = 0; idx < out_shape.size(); ++idx) {
+      if (out_shape[idx] == -1) {
+        th_dynamic_shape_mask[idx] = 1;
+      } else {
+        th_static_shape_mask[idx] = out_shape[idx];
       }
+    }
 
-      auto dynamic_shape_mask = tensor_to_const(ctx, th_dynamic_shape_mask);
-      auto static_shape_mask = tensor_to_const(ctx, th_static_shape_mask);
-      auto input_shape = ctx->net->addShape(*in)->getOutput(0);
-      auto dynamic_shape = ctx->net
-                    ->addElementWise(*input_shape, *dynamic_shape_mask,
-                                     nvinfer1::ElementWiseOperation::kPROD)
-                    ->getOutput(0);
-      auto target_output_shape = ctx->net
-                    ->addElementWise(*dynamic_shape, *static_shape_mask,
-                                     nvinfer1::ElementWiseOperation::kSUM)
-                    ->getOutput(0);
-      resize_layer->setInput(1, *target_output_shape);
+    auto dynamic_shape_mask = tensor_to_const(ctx, th_dynamic_shape_mask);
+    auto static_shape_mask = tensor_to_const(ctx, th_static_shape_mask);
+    auto input_shape = ctx->net->addShape(*in)->getOutput(0);
+    auto dynamic_shape =
+        ctx->net->addElementWise(*input_shape, *dynamic_shape_mask, nvinfer1::ElementWiseOperation::kPROD)
+            ->getOutput(0);
+    auto target_output_shape =
+        ctx->net->addElementWise(*dynamic_shape, *static_shape_mask, nvinfer1::ElementWiseOperation::kSUM)
+            ->getOutput(0);
+    resize_layer->setInput(1, *target_output_shape);
   } else {
-      resize_layer->setScales(scales.data(), scales.size());
-      if (align_corners) {
-        LOG_WARNING("interpolate with align_corners and scale_factor works differently in TensorRT and PyTorch.");
-      }
+    resize_layer->setScales(scales.data(), scales.size());
+    if (align_corners) {
+      LOG_WARNING("interpolate with align_corners and scale_factor works differently in TensorRT and PyTorch.");
+    }
   }
 
   resize_layer->setResizeMode(mode);
@@ -112,555 +110,668 @@ auto interpolate_registrations TRTORCH_UNUSED =
         .pattern(
             {"aten::upsample_nearest1d(Tensor self, int[1] output_size, float? scales=None) -> Tensor",
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                auto in = args[0].ITensor();
-                auto in_shape = util::toVec(in->getDimensions());
+               auto in = args[0].ITensor();
+               auto in_shape = util::toVec(in->getDimensions());
 
-                if (args[1].IValue()->isNone() && args[2].IValue()->isNone()) {
-                  TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nOne of output_size or scales should be defined");
-                } else if (!args[2].IValue()->isNone()) {
-                  // Case 1: user uses scales
-                  float scale = args[2].IValue()->toDouble();
-                  std::vector<float> padded_scales(in_shape.size(), 1);
-                  padded_scales[padded_scales.size() - 1] = scale;
-                  resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kNEAREST);
-                } else {
-                  // Case 2: user uses output size
-                  auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
-                  TRTORCH_ASSERT(
-                      out_size.size() == 1, "aten::upsample_nearest1d input Tensor and output size dimension mismatch");
+               if (args[1].IValue()->isNone() && args[2].IValue()->isNone()) {
+                 TRTORCH_THROW_ERROR(
+                     "Unable to convert node: " << util::node_info(n)
+                                                << "\nOne of output_size or scales should be defined");
+               } else if (!args[2].IValue()->isNone()) {
+                 // Case 1: user uses scales
+                 float scale = args[2].IValue()->toDouble();
+                 std::vector<float> padded_scales(in_shape.size(), 1);
+                 padded_scales[padded_scales.size() - 1] = scale;
+                 resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kNEAREST);
+               } else {
+                 // Case 2: user uses output size
+                 auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
+                 TRTORCH_ASSERT(
+                     out_size.size() == 1, "aten::upsample_nearest1d input Tensor and output size dimension mismatch");
 
-                  auto out_shape = in_shape;
-                  std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
-                  resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kNEAREST);
-                }
+                 auto out_shape = in_shape;
+                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
+                 resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kNEAREST);
+               }
 
-                return true;
+               return true;
              }})
         .pattern(
             {"aten::upsample_nearest1d.vec(Tensor input, int[]? output_size, float[]? scale_factors) -> Tensor",
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                auto in = args[0].ITensor();
-                auto in_shape = util::toVec(in->getDimensions());
+               auto in = args[0].ITensor();
+               auto in_shape = util::toVec(in->getDimensions());
 
-                if (args[1].IValue()->isNone() && args[2].IValue()->isNone()) {
-                  TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nOne of output_size or scale_factors should be defined");
-                } else if (!args[2].IValue()->isNone()) {
-                  // Case 1: user uses scales
-                  auto scale_factors = args[2].unwrapToDoubleList();
-                  TRTORCH_ASSERT(scale_factors.size() == 1, "Number of scale factors should match the input size");
-                  float scale = scale_factors[0];
-                  std::vector<float> padded_scales(in_shape.size(), 1);
-                  padded_scales[padded_scales.size() - 1] = scale;
-                  resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kNEAREST);
-                } else {
-                  // Case 2: user uses output size
-                  auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
-                  TRTORCH_ASSERT(
-                      out_size.size() == 1, "aten::upsample_nearest1d input Tensor and output size dimension mismatch");
+               if (args[1].IValue()->isNone() && args[2].IValue()->isNone()) {
+                 TRTORCH_THROW_ERROR(
+                     "Unable to convert node: " << util::node_info(n)
+                                                << "\nOne of output_size or scale_factors should be defined");
+               } else if (!args[2].IValue()->isNone()) {
+                 // Case 1: user uses scales
+                 auto scale_factors = args[2].unwrapToDoubleList();
+                 TRTORCH_ASSERT(scale_factors.size() == 1, "Number of scale factors should match the input size");
+                 float scale = scale_factors[0];
+                 std::vector<float> padded_scales(in_shape.size(), 1);
+                 padded_scales[padded_scales.size() - 1] = scale;
+                 resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kNEAREST);
+               } else {
+                 // Case 2: user uses output size
+                 auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
+                 TRTORCH_ASSERT(
+                     out_size.size() == 1, "aten::upsample_nearest1d input Tensor and output size dimension mismatch");
 
-                  auto out_shape = in_shape;
-                  std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
-                  resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kNEAREST);
-                }
+                 auto out_shape = in_shape;
+                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
+                 resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kNEAREST);
+               }
 
-                return true;
+               return true;
              }})
         .pattern(
             {"aten::upsample_nearest2d(Tensor self, int[2] output_size, float? scales_h=None, float? scales_w=None) -> Tensor",
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                auto in = args[0].ITensor();
-                auto in_shape = util::toVec(in->getDimensions());
+               auto in = args[0].ITensor();
+               auto in_shape = util::toVec(in->getDimensions());
 
-                if (args[1].IValue()->isNone() && (args[2].IValue()->isNone() || args[3].IValue()->isNone())) {
-                  TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nOne of output_size or scales should be defined");
-                } else if (!args[2].IValue()->isNone() && !args[3].IValue()->isNone()) {
-                  // Case 1: user uses scales
-                  float scale_h = args[2].IValue()->toDouble();
-                  float scale_w = args[3].IValue()->toDouble();
-                  std::vector<float> padded_scales(in_shape.size(), 1);
-                  padded_scales[padded_scales.size() - 2] = scale_h;
-                  padded_scales[padded_scales.size() - 1] = scale_w;
-                  resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kNEAREST);
-                } else {
-                  // Case 2: user uses output size
-                  auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
-                  TRTORCH_ASSERT(
-                      out_size.size() == 2, "aten::upsample_nearest2d input Tensor and output size dimension mismatch");
+               if (args[1].IValue()->isNone() && (args[2].IValue()->isNone() || args[3].IValue()->isNone())) {
+                 TRTORCH_THROW_ERROR(
+                     "Unable to convert node: " << util::node_info(n)
+                                                << "\nOne of output_size or scales should be defined");
+               } else if (!args[2].IValue()->isNone() && !args[3].IValue()->isNone()) {
+                 // Case 1: user uses scales
+                 float scale_h = args[2].IValue()->toDouble();
+                 float scale_w = args[3].IValue()->toDouble();
+                 std::vector<float> padded_scales(in_shape.size(), 1);
+                 padded_scales[padded_scales.size() - 2] = scale_h;
+                 padded_scales[padded_scales.size() - 1] = scale_w;
+                 resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kNEAREST);
+               } else {
+                 // Case 2: user uses output size
+                 auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
+                 TRTORCH_ASSERT(
+                     out_size.size() == 2, "aten::upsample_nearest2d input Tensor and output size dimension mismatch");
 
-                  auto out_shape = in_shape;
-                  std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
-                  resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kNEAREST);
-                }
+                 auto out_shape = in_shape;
+                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
+                 resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kNEAREST);
+               }
 
-                return true;
+               return true;
              }})
         .pattern(
             {"aten::upsample_nearest2d.vec(Tensor input, int[]? output_size, float[]? scale_factors) -> Tensor",
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                auto in = args[0].ITensor();
-                auto in_shape = util::toVec(in->getDimensions());
+               auto in = args[0].ITensor();
+               auto in_shape = util::toVec(in->getDimensions());
 
-                if (args[1].IValue()->isNone() && args[2].IValue()->isNone()) {
-                  TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nOne of output_size or scale_factors should be defined");
-                } else if (!args[2].IValue()->isNone()) {
-                  // Case 1: user uses scales
-                  auto scale_factors = args[2].unwrapToDoubleList();
-                  TRTORCH_ASSERT(scale_factors.size() == 2, "Number of scale factors should match the input size");
-                  float scale_h = scale_factors[0];
-                  float scale_w = scale_factors[1];
-                  std::vector<float> padded_scales(in_shape.size(), 1);
-                  padded_scales[padded_scales.size() - 2] = scale_h;
-                  padded_scales[padded_scales.size() - 1] = scale_w;
-                  resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kNEAREST);
-                } else {
-                  // Case 2: user uses output size
-                  auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
-                  TRTORCH_ASSERT(
-                      out_size.size() == 2, "aten::upsample_nearest2d input Tensor and output size dimension mismatch");
+               if (args[1].IValue()->isNone() && args[2].IValue()->isNone()) {
+                 TRTORCH_THROW_ERROR(
+                     "Unable to convert node: " << util::node_info(n)
+                                                << "\nOne of output_size or scale_factors should be defined");
+               } else if (!args[2].IValue()->isNone()) {
+                 // Case 1: user uses scales
+                 auto scale_factors = args[2].unwrapToDoubleList();
+                 TRTORCH_ASSERT(scale_factors.size() == 2, "Number of scale factors should match the input size");
+                 float scale_h = scale_factors[0];
+                 float scale_w = scale_factors[1];
+                 std::vector<float> padded_scales(in_shape.size(), 1);
+                 padded_scales[padded_scales.size() - 2] = scale_h;
+                 padded_scales[padded_scales.size() - 1] = scale_w;
+                 resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kNEAREST);
+               } else {
+                 // Case 2: user uses output size
+                 auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
+                 TRTORCH_ASSERT(
+                     out_size.size() == 2, "aten::upsample_nearest2d input Tensor and output size dimension mismatch");
 
-                  auto out_shape = in_shape;
-                  std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
-                  resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kNEAREST);
-                }
+                 auto out_shape = in_shape;
+                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
+                 resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kNEAREST);
+               }
 
-                return true;
+               return true;
              }})
         .pattern(
             {"aten::upsample_nearest3d(Tensor self, int[3] output_size, float? scales_d=None, float? scales_h=None, float? scales_w=None) -> Tensor",
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                auto in = args[0].ITensor();
-                auto in_shape = util::toVec(in->getDimensions());
+               auto in = args[0].ITensor();
+               auto in_shape = util::toVec(in->getDimensions());
 
-                if (args[1].IValue()->isNone() && (args[2].IValue()->isNone() || args[3].IValue()->isNone() ||
-                    args[4].IValue()->isNone())) {
-                  TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nOne of output_size or scales should be defined");
-                } else if (!args[2].IValue()->isNone() && !args[3].IValue()->isNone() && !args[4].IValue()->isNone()) {
-                  // Case 1: user uses scales
-                  float scale_d = args[2].IValue()->toDouble();
-                  float scale_h = args[3].IValue()->toDouble();
-                  float scale_w = args[4].IValue()->toDouble();
-                  std::vector<float> padded_scales(in_shape.size(), 1);
-                  padded_scales[padded_scales.size() - 3] = scale_d;
-                  padded_scales[padded_scales.size() - 2] = scale_h;
-                  padded_scales[padded_scales.size() - 1] = scale_w;
-                  resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kNEAREST);
-                } else {
-                  // Case 2: user uses output size
-                  auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
-                  TRTORCH_ASSERT(
-                      out_size.size() == 3, "aten::upsample_nearest3d input Tensor and output size dimension mismatch");
+               if (args[1].IValue()->isNone() &&
+                   (args[2].IValue()->isNone() || args[3].IValue()->isNone() || args[4].IValue()->isNone())) {
+                 TRTORCH_THROW_ERROR(
+                     "Unable to convert node: " << util::node_info(n)
+                                                << "\nOne of output_size or scales should be defined");
+               } else if (!args[2].IValue()->isNone() && !args[3].IValue()->isNone() && !args[4].IValue()->isNone()) {
+                 // Case 1: user uses scales
+                 float scale_d = args[2].IValue()->toDouble();
+                 float scale_h = args[3].IValue()->toDouble();
+                 float scale_w = args[4].IValue()->toDouble();
+                 std::vector<float> padded_scales(in_shape.size(), 1);
+                 padded_scales[padded_scales.size() - 3] = scale_d;
+                 padded_scales[padded_scales.size() - 2] = scale_h;
+                 padded_scales[padded_scales.size() - 1] = scale_w;
+                 resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kNEAREST);
+               } else {
+                 // Case 2: user uses output size
+                 auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
+                 TRTORCH_ASSERT(
+                     out_size.size() == 3, "aten::upsample_nearest3d input Tensor and output size dimension mismatch");
 
-                  auto out_shape = in_shape;
-                  std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
-                  resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kNEAREST);
-                }
+                 auto out_shape = in_shape;
+                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
+                 resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kNEAREST);
+               }
 
-                return true;
+               return true;
              }})
         .pattern(
-            {"aten::upsample_nearest3d.vec(Tensor input, int[]? output_size, float[]? scale_factors) -> Tensor",  // FIX THIS
+            {"aten::upsample_nearest3d.vec(Tensor input, int[]? output_size, float[]? scale_factors) -> Tensor", // FIX
+                                                                                                                 // THIS
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                auto in = args[0].ITensor();
-                auto in_shape = util::toVec(in->getDimensions());
+               auto in = args[0].ITensor();
+               auto in_shape = util::toVec(in->getDimensions());
 
-                if (args[1].IValue()->isNone() && args[2].IValue()->isNone()) {
-                  TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nOne of output_size or scale_factors should be defined");
-                } else if (!args[2].IValue()->isNone()) {
-                  // Case 1: user uses scales
-                  auto scale_factors = args[2].unwrapToDoubleList();
-                  TRTORCH_ASSERT(scale_factors.size() == 3, "Number of scale factors should match the input size");
-                  float scale_d = scale_factors[0];
-                  float scale_h = scale_factors[1];
-                  float scale_w = scale_factors[2];
-                  std::vector<float> padded_scales(in_shape.size(), 1);
-                  padded_scales[padded_scales.size() - 3] = scale_d;
-                  padded_scales[padded_scales.size() - 2] = scale_h;
-                  padded_scales[padded_scales.size() - 1] = scale_w;
-                  resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kNEAREST);
-                } else {
-                  // Case 2: user uses output size
-                  auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
-                  TRTORCH_ASSERT(
-                      out_size.size() == 3, "aten::upsample_nearest3d input Tensor and output size dimension mismatch");
+               if (args[1].IValue()->isNone() && args[2].IValue()->isNone()) {
+                 TRTORCH_THROW_ERROR(
+                     "Unable to convert node: " << util::node_info(n)
+                                                << "\nOne of output_size or scale_factors should be defined");
+               } else if (!args[2].IValue()->isNone()) {
+                 // Case 1: user uses scales
+                 auto scale_factors = args[2].unwrapToDoubleList();
+                 TRTORCH_ASSERT(scale_factors.size() == 3, "Number of scale factors should match the input size");
+                 float scale_d = scale_factors[0];
+                 float scale_h = scale_factors[1];
+                 float scale_w = scale_factors[2];
+                 std::vector<float> padded_scales(in_shape.size(), 1);
+                 padded_scales[padded_scales.size() - 3] = scale_d;
+                 padded_scales[padded_scales.size() - 2] = scale_h;
+                 padded_scales[padded_scales.size() - 1] = scale_w;
+                 resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kNEAREST);
+               } else {
+                 // Case 2: user uses output size
+                 auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
+                 TRTORCH_ASSERT(
+                     out_size.size() == 3, "aten::upsample_nearest3d input Tensor and output size dimension mismatch");
 
-                  auto out_shape = in_shape;
-                  std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
-                  resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kNEAREST);
-                }
+                 auto out_shape = in_shape;
+                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
+                 resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kNEAREST);
+               }
 
-                return true;
+               return true;
              }})
         .pattern(
             {"aten::upsample_linear1d(Tensor self, int[1] output_size, bool align_corners, float? scales=None) -> Tensor",
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                auto in = args[0].ITensor();
-                auto in_shape = util::toVec(in->getDimensions());
-                bool align_corners = args[2].unwrapToBool();
+               auto in = args[0].ITensor();
+               auto in_shape = util::toVec(in->getDimensions());
+               bool align_corners = args[2].unwrapToBool();
 
-                if (args[1].IValue()->isNone() && args[3].IValue()->isNone()) {
-                  TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nOne of output_size or scales should be defined");
-                } else if (!args[3].IValue()->isNone()) {
-                  // Case 1: user uses scales
-                  float scale = args[3].IValue()->toDouble();
-                  std::vector<float> padded_scales(in_shape.size(), 1);
-                  padded_scales[padded_scales.size() - 1] = scale;
-              #if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
-                  if (!align_corners) {
-                    TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nupsample_linear1d only supports align_corner with TensorRT <= 7.0.");
-                  } else {
-                    resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, true);
-                  }
-              #else
-                  TRTORCH_CHECK(!(align_corners && ctx->input_is_dynamic),
-                    "TRTorch currently does not support the compilation of dynamc engines from code using using PyTorch [bi/tri]linear interpolation via scale factor and align_corners=True");
-                  if (align_corners) {
-                    // Align corners and scale factor behave slightly different together in TRT and PyTorch so run the
-                    // layer in ATen to maintain consistancy between TRTorch and PyTorch
-                    // https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
-                    create_plugin(ctx, n, in, "linear1d", in_shape, {}, {}, {scale}, std::string("linear"), align_corners, true);
-                  } else {
-                    resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, align_corners);
-                  }
-              #endif
-                } else {
-                  // Case 2: user uses output size
-                  auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
-                  TRTORCH_ASSERT(
-                      out_size.size() == 1, "aten::upsample_linear1d input Tensor and output size dimension mismatch");
+               if (args[1].IValue()->isNone() && args[3].IValue()->isNone()) {
+                 TRTORCH_THROW_ERROR(
+                     "Unable to convert node: " << util::node_info(n)
+                                                << "\nOne of output_size or scales should be defined");
+               } else if (!args[3].IValue()->isNone()) {
+                 // Case 1: user uses scales
+                 float scale = args[3].IValue()->toDouble();
+                 std::vector<float> padded_scales(in_shape.size(), 1);
+                 padded_scales[padded_scales.size() - 1] = scale;
+#if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
+                 if (!align_corners) {
+                   TRTORCH_THROW_ERROR(
+                       "Unable to convert node: "
+                       << util::node_info(n) << "\nupsample_linear1d only supports align_corner with TensorRT <= 7.0.");
+                 } else {
+                   resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, true);
+                 }
+#else
+                 TRTORCH_CHECK(
+                     !(align_corners && ctx->input_is_dynamic),
+                     "TRTorch currently does not support the compilation of dynamc engines from code using using PyTorch [bi/tri]linear interpolation via scale factor and align_corners=True");
+                 if (align_corners) {
+                   // Align corners and scale factor behave slightly different together in TRT and PyTorch so run the
+                   // layer in ATen to maintain consistancy between TRTorch and PyTorch
+                   // https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
+                   create_plugin(
+                       ctx, n, in, "linear1d", in_shape, {}, {}, {scale}, std::string("linear"), align_corners, true);
+                 } else {
+                   resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, align_corners);
+                 }
+#endif
+               } else {
+                 // Case 2: user uses output size
+                 auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
+                 TRTORCH_ASSERT(
+                     out_size.size() == 1, "aten::upsample_linear1d input Tensor and output size dimension mismatch");
 
-                  auto out_shape = in_shape;
-                  std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
-              #if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
-                  if (!align_corners) {
-                    // align_corners not supported in TensorRT, create plugin and
-                    // run layer through PyTorch
-                    create_plugin(ctx, n, in, "linear1d", in_shape, out_shape, out_size, {}, std::string("linear"), align_corners);
-                  } else {
-                    resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, true);
-                  }
-              #else
-                  resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, align_corners);
-              #endif
-                }
+                 auto out_shape = in_shape;
+                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
+#if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
+                 if (!align_corners) {
+                   // align_corners not supported in TensorRT, create plugin and
+                   // run layer through PyTorch
+                   create_plugin(
+                       ctx, n, in, "linear1d", in_shape, out_shape, out_size, {}, std::string("linear"), align_corners);
+                 } else {
+                   resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, true);
+                 }
+#else
+                 resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, align_corners);
+#endif
+               }
 
-                return true;
+               return true;
              }})
         .pattern(
             {"aten::upsample_linear1d.vec(Tensor input, int[]? output_size, bool align_corners, float[]? scale_factors) -> Tensor",
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                auto in = args[0].ITensor();
-                auto in_shape = util::toVec(in->getDimensions());
-                bool align_corners = args[2].unwrapToBool();
+               auto in = args[0].ITensor();
+               auto in_shape = util::toVec(in->getDimensions());
+               bool align_corners = args[2].unwrapToBool();
 
-                if (args[1].IValue()->isNone() && args[3].IValue()->isNone()) {
-                  TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nOne of output_size or scale_factors should be defined");
-                } else if (!args[3].IValue()->isNone()) {
-                  // Case 1: user uses scales
-                  auto scale_factors = args[3].unwrapToDoubleList();
-                  TRTORCH_ASSERT(scale_factors.size() == 1, "Number of scale factors should match the input size");
-                  float scale = scale_factors[0];
-                  std::vector<float> padded_scales(in_shape.size(), 1);
-                  padded_scales[padded_scales.size() - 1] = scale;
-              #if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
-                  if (!align_corners) {
-                    TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nupsample_linear1d only supports align_corner with TensorRT <= 7.0.");
-                  } else {
-                    resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, true);
-                  }
-              #else
-                  TRTORCH_CHECK(!(align_corners && ctx->input_is_dynamic),
-                    "TRTorch currently does not support the compilation of dynamc engines from code using PyTorch [bi/tri]linear interpolation via scale factor and align_corners=True");
-                  if (align_corners) {
-                    // Align corners and scale factor behave slightly different together in TRT and PyTorch so run the
-                    // layer in ATen to maintain consistancy between TRTorch and PyTorch
-                    // https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
-                    create_plugin(ctx, n, in, "linear1d", in_shape, {}, {}, {scale}, std::string("linear"), align_corners, true);
-                  } else {
-                    resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, align_corners);
-                  }
-              #endif
-                } else {
-                  // Case 2: user uses output size
-                  auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
-                  TRTORCH_ASSERT(
-                      out_size.size() == 1, "aten::upsample_linear1d input Tensor and output size dimension mismatch");
+               if (args[1].IValue()->isNone() && args[3].IValue()->isNone()) {
+                 TRTORCH_THROW_ERROR(
+                     "Unable to convert node: " << util::node_info(n)
+                                                << "\nOne of output_size or scale_factors should be defined");
+               } else if (!args[3].IValue()->isNone()) {
+                 // Case 1: user uses scales
+                 auto scale_factors = args[3].unwrapToDoubleList();
+                 TRTORCH_ASSERT(scale_factors.size() == 1, "Number of scale factors should match the input size");
+                 float scale = scale_factors[0];
+                 std::vector<float> padded_scales(in_shape.size(), 1);
+                 padded_scales[padded_scales.size() - 1] = scale;
+#if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
+                 if (!align_corners) {
+                   TRTORCH_THROW_ERROR(
+                       "Unable to convert node: "
+                       << util::node_info(n) << "\nupsample_linear1d only supports align_corner with TensorRT <= 7.0.");
+                 } else {
+                   resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, true);
+                 }
+#else
+                 TRTORCH_CHECK(
+                     !(align_corners && ctx->input_is_dynamic),
+                     "TRTorch currently does not support the compilation of dynamc engines from code using PyTorch [bi/tri]linear interpolation via scale factor and align_corners=True");
+                 if (align_corners) {
+                   // Align corners and scale factor behave slightly different together in TRT and PyTorch so run the
+                   // layer in ATen to maintain consistancy between TRTorch and PyTorch
+                   // https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
+                   create_plugin(
+                       ctx, n, in, "linear1d", in_shape, {}, {}, {scale}, std::string("linear"), align_corners, true);
+                 } else {
+                   resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, align_corners);
+                 }
+#endif
+               } else {
+                 // Case 2: user uses output size
+                 auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
+                 TRTORCH_ASSERT(
+                     out_size.size() == 1, "aten::upsample_linear1d input Tensor and output size dimension mismatch");
 
-                  auto out_shape = in_shape;
-                  std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
-              #if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
-                  if (!align_corners) {
-                    // align_corners not supported in TensorRT, create plugin and
-                    // run layer through PyTorch
-                    create_plugin(ctx, n, in, "linear1d", in_shape, out_shape, out_size, {}, std::string("linear"), align_corners);
-                  } else {
-                    resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, true);
-                  }
-              #else
-                  resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, align_corners);
-              #endif
-                }
+                 auto out_shape = in_shape;
+                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
+#if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
+                 if (!align_corners) {
+                   // align_corners not supported in TensorRT, create plugin and
+                   // run layer through PyTorch
+                   create_plugin(
+                       ctx, n, in, "linear1d", in_shape, out_shape, out_size, {}, std::string("linear"), align_corners);
+                 } else {
+                   resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, true);
+                 }
+#else
+                 resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, align_corners);
+#endif
+               }
 
-                return true;
+               return true;
              }})
         .pattern(
             {"aten::upsample_bilinear2d(Tensor self, int[2] output_size, bool align_corners, float? scales_h=None, float? scales_w=None) -> Tensor",
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                auto in = args[0].ITensor();
-                auto in_shape = util::toVec(in->getDimensions());
-                bool align_corners = args[2].unwrapToBool();
+               auto in = args[0].ITensor();
+               auto in_shape = util::toVec(in->getDimensions());
+               bool align_corners = args[2].unwrapToBool();
 
-                if (args[1].IValue()->isNone() && (args[3].IValue()->isNone() || args[4].IValue()->isNone())) {
-                  TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nOne of output_size or scales should be defined");
-                } else if (!args[3].IValue()->isNone() && !args[4].IValue()->isNone()) {
-                  // Case 1: user uses scales
-                  float scale_h = args[3].IValue()->toDouble();
-                  float scale_w = args[4].IValue()->toDouble();
-                  std::vector<float> padded_scales(in_shape.size(), 1);
-                  padded_scales[padded_scales.size() - 2] = scale_h;
-                  padded_scales[padded_scales.size() - 1] = scale_w;
-              #if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
-                  if (!align_corners) {
-                    TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nupsample_linear2d only supports align_corner with TensorRT <= 7.0.");
-                  } else {
-                    resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, true);
-                  }
-              #else
-                  TRTORCH_CHECK(!(align_corners && ctx->input_is_dynamic),
-                    "TRTorch currently does not support the compilation of dynamc engines from code using PyTorch [bi/tri]linear interpolation via scale factor and align_corners=True");
-                  if (align_corners) {
-                    // Align corners and scale factor behave slightly different together in TRT and PyTorch so run the
-                    // layer in ATen to maintain consistancy between TRTorch and PyTorch
-                    // https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
-                    create_plugin(ctx, n, in, "bilinear2d", in_shape, {}, {}, {scale_h, scale_w}, std::string("bilinear"), align_corners, true);
-                  } else {
-                    resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, align_corners);
-                  }
-              #endif
-                } else {
-                  // Case 2: user uses output size
-                  auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
+               if (args[1].IValue()->isNone() && (args[3].IValue()->isNone() || args[4].IValue()->isNone())) {
+                 TRTORCH_THROW_ERROR(
+                     "Unable to convert node: " << util::node_info(n)
+                                                << "\nOne of output_size or scales should be defined");
+               } else if (!args[3].IValue()->isNone() && !args[4].IValue()->isNone()) {
+                 // Case 1: user uses scales
+                 float scale_h = args[3].IValue()->toDouble();
+                 float scale_w = args[4].IValue()->toDouble();
+                 std::vector<float> padded_scales(in_shape.size(), 1);
+                 padded_scales[padded_scales.size() - 2] = scale_h;
+                 padded_scales[padded_scales.size() - 1] = scale_w;
+#if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
+                 if (!align_corners) {
+                   TRTORCH_THROW_ERROR(
+                       "Unable to convert node: "
+                       << util::node_info(n) << "\nupsample_linear2d only supports align_corner with TensorRT <= 7.0.");
+                 } else {
+                   resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, true);
+                 }
+#else
+                 TRTORCH_CHECK(
+                     !(align_corners && ctx->input_is_dynamic),
+                     "TRTorch currently does not support the compilation of dynamc engines from code using PyTorch [bi/tri]linear interpolation via scale factor and align_corners=True");
+                 if (align_corners) {
+                   // Align corners and scale factor behave slightly different together in TRT and PyTorch so run the
+                   // layer in ATen to maintain consistancy between TRTorch and PyTorch
+                   // https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
+                   create_plugin(
+                       ctx,
+                       n,
+                       in,
+                       "bilinear2d",
+                       in_shape,
+                       {},
+                       {},
+                       {scale_h, scale_w},
+                       std::string("bilinear"),
+                       align_corners,
+                       true);
+                 } else {
+                   resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, align_corners);
+                 }
+#endif
+               } else {
+                 // Case 2: user uses output size
+                 auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
 
-                  TRTORCH_ASSERT(
-                      out_size.size() == 2, "aten::upsample_bilinear2d input Tensor and output size dimension mismatch");
+                 TRTORCH_ASSERT(
+                     out_size.size() == 2, "aten::upsample_bilinear2d input Tensor and output size dimension mismatch");
 
-                  auto out_shape = in_shape;
-                  std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
+                 auto out_shape = in_shape;
+                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
 
-              #if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
-                  if (!align_corners) {
-                    // align_corners not supported in TensorRT, create plugin and
-                    // run layer through PyTorch
-                    create_plugin(ctx, n, in, "bilinear2d", in_shape, out_shape, out_size, {}, std::string("bilinear"), align_corners);
-                  } else {
-                    resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, true);
-                  }
-              #else
-                  resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, align_corners);
-              #endif
-                }
+#if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
+                 if (!align_corners) {
+                   // align_corners not supported in TensorRT, create plugin and
+                   // run layer through PyTorch
+                   create_plugin(
+                       ctx,
+                       n,
+                       in,
+                       "bilinear2d",
+                       in_shape,
+                       out_shape,
+                       out_size,
+                       {},
+                       std::string("bilinear"),
+                       align_corners);
+                 } else {
+                   resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, true);
+                 }
+#else
+                 resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, align_corners);
+#endif
+               }
 
-                return true;
+               return true;
              }})
         .pattern(
             {"aten::upsample_bilinear2d.vec(Tensor input, int[]? output_size, bool align_corners, float[]? scale_factors) -> Tensor",
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                auto in = args[0].ITensor();
-                auto in_shape = util::toVec(in->getDimensions());
-                bool align_corners = args[2].unwrapToBool();
+               auto in = args[0].ITensor();
+               auto in_shape = util::toVec(in->getDimensions());
+               bool align_corners = args[2].unwrapToBool();
 
-                if (args[1].IValue()->isNone() && args[3].IValue()->isNone()) {
-                  TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nOne of output_size or scale_factors should be defined");
-                } else if (!args[3].IValue()->isNone()) {
-                  // Case 1: user uses scales
-                  auto scale_factors = args[3].unwrapToDoubleList();
-                  TRTORCH_ASSERT(scale_factors.size() == 2, "Number of scale factors should match the input size");
-                  float scale_h = scale_factors[0];
-                  float scale_w = scale_factors[1];
-                  std::vector<float> padded_scales(in_shape.size(), 1);
-                  padded_scales[padded_scales.size() - 2] = scale_h;
-                  padded_scales[padded_scales.size() - 1] = scale_w;
-              #if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
-                  if (!align_corners) {
-                    TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nupsample_linear2d only supports align_corner with TensorRT <= 7.0.");
-                  } else {
-                    resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, true);
-                  }
-              #else
-                  TRTORCH_CHECK(!(align_corners && ctx->input_is_dynamic),
-                    "TRTorch currently does not support the compilation of dynamc engines from code using PyTorch [bi/tri]linear interpolation via scale factor and align_corners=True");
-                  if (align_corners) {
-                    // Align corners and scale factor behave slightly different together in TRT and PyTorch so run the
-                    // layer in ATen to maintain consistancy between TRTorch and PyTorch
-                    // https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
-                    create_plugin(ctx, n, in, "bilinear2d", in_shape, {}, {}, scale_factors.vec(), std::string("bilinear"), align_corners, true);
-                  } else {
-                    resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, align_corners);
-                  }
-              #endif
-                } else {
-                  // Case 2: user uses output size
-                  auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
+               if (args[1].IValue()->isNone() && args[3].IValue()->isNone()) {
+                 TRTORCH_THROW_ERROR(
+                     "Unable to convert node: " << util::node_info(n)
+                                                << "\nOne of output_size or scale_factors should be defined");
+               } else if (!args[3].IValue()->isNone()) {
+                 // Case 1: user uses scales
+                 auto scale_factors = args[3].unwrapToDoubleList();
+                 TRTORCH_ASSERT(scale_factors.size() == 2, "Number of scale factors should match the input size");
+                 float scale_h = scale_factors[0];
+                 float scale_w = scale_factors[1];
+                 std::vector<float> padded_scales(in_shape.size(), 1);
+                 padded_scales[padded_scales.size() - 2] = scale_h;
+                 padded_scales[padded_scales.size() - 1] = scale_w;
+#if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
+                 if (!align_corners) {
+                   TRTORCH_THROW_ERROR(
+                       "Unable to convert node: "
+                       << util::node_info(n) << "\nupsample_linear2d only supports align_corner with TensorRT <= 7.0.");
+                 } else {
+                   resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, true);
+                 }
+#else
+                 TRTORCH_CHECK(
+                     !(align_corners && ctx->input_is_dynamic),
+                     "TRTorch currently does not support the compilation of dynamc engines from code using PyTorch [bi/tri]linear interpolation via scale factor and align_corners=True");
+                 if (align_corners) {
+                   // Align corners and scale factor behave slightly different together in TRT and PyTorch so run the
+                   // layer in ATen to maintain consistancy between TRTorch and PyTorch
+                   // https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
+                   create_plugin(
+                       ctx,
+                       n,
+                       in,
+                       "bilinear2d",
+                       in_shape,
+                       {},
+                       {},
+                       scale_factors.vec(),
+                       std::string("bilinear"),
+                       align_corners,
+                       true);
+                 } else {
+                   resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, align_corners);
+                 }
+#endif
+               } else {
+                 // Case 2: user uses output size
+                 auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
 
-                  TRTORCH_ASSERT(
-                      out_size.size() == 2, "aten::upsample_bilinear2d input Tensor and output size dimension mismatch");
+                 TRTORCH_ASSERT(
+                     out_size.size() == 2, "aten::upsample_bilinear2d input Tensor and output size dimension mismatch");
 
-                  auto out_shape = in_shape;
-                  std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
+                 auto out_shape = in_shape;
+                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
 
-              #if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
-                  if (!align_corners) {
-                    // align_corners not supported in TensorRT, create plugin and
-                    // run layer through PyTorch
-                    create_plugin(ctx, n, in, "bilinear2d", in_shape, out_shape, out_size, {}, std::string("bilinear"), align_corners);
-                  } else {
-                    resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, true);
-                  }
-              #else
-                  resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, align_corners);
-              #endif
-                }
+#if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
+                 if (!align_corners) {
+                   // align_corners not supported in TensorRT, create plugin and
+                   // run layer through PyTorch
+                   create_plugin(
+                       ctx,
+                       n,
+                       in,
+                       "bilinear2d",
+                       in_shape,
+                       out_shape,
+                       out_size,
+                       {},
+                       std::string("bilinear"),
+                       align_corners);
+                 } else {
+                   resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, true);
+                 }
+#else
+                 resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, align_corners);
+#endif
+               }
 
-                return true;
+               return true;
              }})
         .pattern(
             {"aten::upsample_trilinear3d(Tensor self, int[3] output_size, bool align_corners, float? scales_d=None, float? scales_h=None, float? scales_w=None) -> (Tensor)",
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-                auto in = args[0].ITensor();
-                auto in_shape = util::toVec(in->getDimensions());
-                bool align_corners = args[2].unwrapToBool();
+               auto in = args[0].ITensor();
+               auto in_shape = util::toVec(in->getDimensions());
+               bool align_corners = args[2].unwrapToBool();
 
-                if (args[1].IValue()->isNone() && (args[3].IValue()->isNone() || args[4].IValue()->isNone() || args[5].IValue()->isNone())) {
-                  TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nOne of size or scales should be defined");
-                } else if (!args[3].IValue()->isNone() && !args[4].IValue()->isNone() && !args[5].IValue()->isNone()) {
-                  // Case 1: user uses scales
-                  float scale_d = args[3].IValue()->toDouble();
-                  float scale_h = args[4].IValue()->toDouble();
-                  float scale_w = args[5].IValue()->toDouble();
-                  std::vector<float> padded_scales(in_shape.size(), 1);
-                  padded_scales[padded_scales.size() - 3] = scale_d;
-                  padded_scales[padded_scales.size() - 2] = scale_h;
-                  padded_scales[padded_scales.size() - 1] = scale_w;
-              #if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
-                  if (!align_corners) {
-                    TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                      << "\nupsample_linear3d only supports align_corner with TensorRT <= 7.0.");
-                  } else {
-                    resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, true);
-                  }
-              #else
-                  TRTORCH_CHECK(!(align_corners && ctx->input_is_dynamic),
-                    "TRTorch currently does not support the compilation of dynamc engines from code using PyTorch [bi/tri]linear interpolation via scale factor and align_corners=True");
-                  if (align_corners) {
-                    // Align corners and scale factor behave slightly different together in TRT and PyTorch so run the
-                    // layer in ATen to maintain consistancy between TRTorch and PyTorch
-                    // https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
-                    create_plugin(ctx, n, in, "trilinear3d", in_shape, {}, {}, {scale_d, scale_h, scale_w}, std::string("trilinear"), align_corners, true);
-                  } else {
-                    resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, align_corners);
-                  }
-              #endif
-                } else {
-                  // Case 2: user uses output size
-                  auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
-                  TRTORCH_ASSERT(
-                      out_size.size() == 3,
-                      "aten::upsample_trilinear3d input Tensor and output size dimension mismatch");
+               if (args[1].IValue()->isNone() &&
+                   (args[3].IValue()->isNone() || args[4].IValue()->isNone() || args[5].IValue()->isNone())) {
+                 TRTORCH_THROW_ERROR(
+                     "Unable to convert node: " << util::node_info(n) << "\nOne of size or scales should be defined");
+               } else if (!args[3].IValue()->isNone() && !args[4].IValue()->isNone() && !args[5].IValue()->isNone()) {
+                 // Case 1: user uses scales
+                 float scale_d = args[3].IValue()->toDouble();
+                 float scale_h = args[4].IValue()->toDouble();
+                 float scale_w = args[5].IValue()->toDouble();
+                 std::vector<float> padded_scales(in_shape.size(), 1);
+                 padded_scales[padded_scales.size() - 3] = scale_d;
+                 padded_scales[padded_scales.size() - 2] = scale_h;
+                 padded_scales[padded_scales.size() - 1] = scale_w;
+#if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
+                 if (!align_corners) {
+                   TRTORCH_THROW_ERROR(
+                       "Unable to convert node: "
+                       << util::node_info(n) << "\nupsample_linear3d only supports align_corner with TensorRT <= 7.0.");
+                 } else {
+                   resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, true);
+                 }
+#else
+                 TRTORCH_CHECK(
+                     !(align_corners && ctx->input_is_dynamic),
+                     "TRTorch currently does not support the compilation of dynamc engines from code using PyTorch [bi/tri]linear interpolation via scale factor and align_corners=True");
+                 if (align_corners) {
+                   // Align corners and scale factor behave slightly different together in TRT and PyTorch so run the
+                   // layer in ATen to maintain consistancy between TRTorch and PyTorch
+                   // https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
+                   create_plugin(
+                       ctx,
+                       n,
+                       in,
+                       "trilinear3d",
+                       in_shape,
+                       {},
+                       {},
+                       {scale_d, scale_h, scale_w},
+                       std::string("trilinear"),
+                       align_corners,
+                       true);
+                 } else {
+                   resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, align_corners);
+                 }
+#endif
+               } else {
+                 // Case 2: user uses output size
+                 auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
+                 TRTORCH_ASSERT(
+                     out_size.size() == 3,
+                     "aten::upsample_trilinear3d input Tensor and output size dimension mismatch");
 
-                  auto out_shape = in_shape;
-                  std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
-              #if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
-                  if (!align_corners) {
-                    // align_corners not supported in TensorRT, create plugin and
-                    // run layer through PyTorch
-                    create_plugin(ctx, n, in, "trilinear3d", in_shape, out_shape, out_size, {}, std::string("trilinear"), align_corners);
-                  } else {
-                    resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, true);
-                  }
-              #else
-                  resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, align_corners);
-              #endif
-                }
+                 auto out_shape = in_shape;
+                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
+#if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
+                 if (!align_corners) {
+                   // align_corners not supported in TensorRT, create plugin and
+                   // run layer through PyTorch
+                   create_plugin(
+                       ctx,
+                       n,
+                       in,
+                       "trilinear3d",
+                       in_shape,
+                       out_shape,
+                       out_size,
+                       {},
+                       std::string("trilinear"),
+                       align_corners);
+                 } else {
+                   resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, true);
+                 }
+#else
+                 resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, align_corners);
+#endif
+               }
 
-                return true;
+               return true;
              }})
         .pattern(
             {"aten::upsample_trilinear3d.vec(Tensor input, int[]? output_size, bool align_corners, float[]? scale_factors) -> Tensor",
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
-              auto in = args[0].ITensor();
-              auto in_shape = util::toVec(in->getDimensions());
-              bool align_corners = args[2].unwrapToBool();
+               auto in = args[0].ITensor();
+               auto in_shape = util::toVec(in->getDimensions());
+               bool align_corners = args[2].unwrapToBool();
 
-              if (args[1].IValue()->isNone() && args[3].IValue()->isNone()) {
-                TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                    << "\nOne of size or scale_factors should be defined");
-              } else if (!args[3].IValue()->isNone()) {
-                // Case 1: user uses scales
-                auto scale_factors = args[3].unwrapToDoubleList();
-                TRTORCH_ASSERT(scale_factors.size() == 3, "Number of scale factors should match the input size");
-                float scale_d = scale_factors[0];
-                float scale_h = scale_factors[1];
-                float scale_w = scale_factors[2];
-                std::vector<float> padded_scales(in_shape.size(), 1);
-                padded_scales[padded_scales.size() - 3] = scale_d;
-                padded_scales[padded_scales.size() - 2] = scale_h;
-                padded_scales[padded_scales.size() - 1] = scale_w;
-            #if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
-                if (!align_corners) {
-                  TRTORCH_THROW_ERROR("Unable to convert node: " << util::node_info(n)
-                                    << "\nupsample_linear3d only supports align_corner with TensorRT <= 7.0.");
-                } else {
-                  resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, true);
-                }
-            #else
-                TRTORCH_CHECK(!(align_corners && ctx->input_is_dynamic),
-                    "TRTorch currently does not support the compilation of dynamc engines from code using PyTorch [bi/tri]linear interpolation via scale factor and align_corners=True");
-                  if (align_corners) {
-                    // Align corners and scale factor behave slightly different together in TRT and PyTorch so run the
-                    // layer in ATen to maintain consistancy between TRTorch and PyTorch
-                    // https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
-                    create_plugin(ctx, n, in, "trilinear3d", in_shape, {}, {}, scale_factors.vec(), std::string("trilinear"), align_corners, true);
-                  } else {
-                    resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, align_corners);
-                  }
-            #endif
-              } else {
-                // Case 2: user uses output size
-                auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
-                TRTORCH_ASSERT(
-                    out_size.size() == 3,
-                    "aten::upsample_trilinear3d input Tensor and output size dimension mismatch");
+               if (args[1].IValue()->isNone() && args[3].IValue()->isNone()) {
+                 TRTORCH_THROW_ERROR(
+                     "Unable to convert node: " << util::node_info(n)
+                                                << "\nOne of size or scale_factors should be defined");
+               } else if (!args[3].IValue()->isNone()) {
+                 // Case 1: user uses scales
+                 auto scale_factors = args[3].unwrapToDoubleList();
+                 TRTORCH_ASSERT(scale_factors.size() == 3, "Number of scale factors should match the input size");
+                 float scale_d = scale_factors[0];
+                 float scale_h = scale_factors[1];
+                 float scale_w = scale_factors[2];
+                 std::vector<float> padded_scales(in_shape.size(), 1);
+                 padded_scales[padded_scales.size() - 3] = scale_d;
+                 padded_scales[padded_scales.size() - 2] = scale_h;
+                 padded_scales[padded_scales.size() - 1] = scale_w;
+#if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
+                 if (!align_corners) {
+                   TRTORCH_THROW_ERROR(
+                       "Unable to convert node: "
+                       << util::node_info(n) << "\nupsample_linear3d only supports align_corner with TensorRT <= 7.0.");
+                 } else {
+                   resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, true);
+                 }
+#else
+                 TRTORCH_CHECK(
+                     !(align_corners && ctx->input_is_dynamic),
+                     "TRTorch currently does not support the compilation of dynamc engines from code using PyTorch [bi/tri]linear interpolation via scale factor and align_corners=True");
+                 if (align_corners) {
+                   // Align corners and scale factor behave slightly different together in TRT and PyTorch so run the
+                   // layer in ATen to maintain consistancy between TRTorch and PyTorch
+                   // https://pytorch.org/docs/stable/nn.functional.html#torch.nn.functional.interpolate
+                   create_plugin(
+                       ctx,
+                       n,
+                       in,
+                       "trilinear3d",
+                       in_shape,
+                       {},
+                       {},
+                       scale_factors.vec(),
+                       std::string("trilinear"),
+                       align_corners,
+                       true);
+                 } else {
+                   resize_layer_size(ctx, n, in, {}, padded_scales, nvinfer1::ResizeMode::kLINEAR, align_corners);
+                 }
+#endif
+               } else {
+                 // Case 2: user uses output size
+                 auto out_size = util::toVec(util::toDims(args[1].unwrapToIntList()));
+                 TRTORCH_ASSERT(
+                     out_size.size() == 3,
+                     "aten::upsample_trilinear3d input Tensor and output size dimension mismatch");
 
-                auto out_shape = in_shape;
-                std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
-            #if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
-                if (!align_corners) {
-                  // align_corners not supported in TensorRT, create plugin and
-                  // run layer through PyTorch
-                  create_plugin(ctx, n, in, "trilinear3d", in_shape, out_shape, out_size, {}, std::string("trilinear"), align_corners);
-                } else {
-                  resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, true);
-                }
-            #else
-                resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, align_corners);
-            #endif
-              }
+                 auto out_shape = in_shape;
+                 std::copy(out_size.begin(), out_size.end(), out_shape.begin() + (in_shape.size() - out_size.size()));
+#if NV_TENSORRT_MAJOR < 7 || (NV_TENSORRT_MAJOR == 7 && NV_TENSORRT_MINOR < 1) // IF TRT VERSION <= 7.0
+                 if (!align_corners) {
+                   // align_corners not supported in TensorRT, create plugin and
+                   // run layer through PyTorch
+                   create_plugin(
+                       ctx,
+                       n,
+                       in,
+                       "trilinear3d",
+                       in_shape,
+                       out_shape,
+                       out_size,
+                       {},
+                       std::string("trilinear"),
+                       align_corners);
+                 } else {
+                   resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, true);
+                 }
+#else
+                 resize_layer_size(ctx, n, in, out_shape, {}, nvinfer1::ResizeMode::kLINEAR, align_corners);
+#endif
+               }
 
-              return true;
+               return true;
              }});
 
 } // namespace

--- a/core/conversion/converters/impl/plugins/interpolate_plugin.h
+++ b/core/conversion/converters/impl/plugins/interpolate_plugin.h
@@ -140,14 +140,14 @@ class InterpolatePluginCreator : public nvinfer1::IPluginCreator {
   nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) override;
 
   InterpolatePlugin* createPlugin(
-    const char* name,
-    std::vector<int64_t> in_shape,
-    std::vector<int64_t> out_shape,
-    std::vector<int64_t> size,
-    std::vector<double> scales,
-    std::string mode,
-    bool align_corners,
-    bool use_scales);
+      const char* name,
+      std::vector<int64_t> in_shape,
+      std::vector<int64_t> out_shape,
+      std::vector<int64_t> size,
+      std::vector<double> scales,
+      std::string mode,
+      bool align_corners,
+      bool use_scales);
 
   nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) override;
 

--- a/core/conversion/converters/impl/plugins/interpolate_plugin.h
+++ b/core/conversion/converters/impl/plugins/interpolate_plugin.h
@@ -31,8 +31,10 @@ class InterpolatePlugin : public nvinfer1::IPluginV2DynamicExt {
   std::vector<int64_t> in_shape_;
   std::vector<int64_t> out_shape_;
   std::vector<int64_t> size_;
+  std::vector<double> scales_;
   std::string mode_;
   bool align_corners_;
+  bool use_scales_;
 
  protected:
   // To prevent compiler warnings
@@ -49,8 +51,10 @@ class InterpolatePlugin : public nvinfer1::IPluginV2DynamicExt {
       std::vector<int64_t> in_shape,
       std::vector<int64_t> out_shape,
       std::vector<int64_t> size,
+      std::vector<double> scales,
       std::string mode,
-      bool align_corners);
+      bool align_corners,
+      bool use_scales);
 
   InterpolatePlugin(const char* data, size_t length);
 
@@ -136,12 +140,14 @@ class InterpolatePluginCreator : public nvinfer1::IPluginCreator {
   nvinfer1::IPluginV2* createPlugin(const char* name, const nvinfer1::PluginFieldCollection* fc) override;
 
   InterpolatePlugin* createPlugin(
-      const char* name,
-      std::vector<int64_t> in_shape,
-      std::vector<int64_t> out_shape,
-      std::vector<int64_t> size,
-      std::string mode,
-      bool align_corners);
+    const char* name,
+    std::vector<int64_t> in_shape,
+    std::vector<int64_t> out_shape,
+    std::vector<int64_t> size,
+    std::vector<double> scales,
+    std::string mode,
+    bool align_corners,
+    bool use_scales);
 
   nvinfer1::IPluginV2* deserializePlugin(const char* name, const void* serialData, size_t serialLength) override;
 

--- a/core/conversion/converters/impl/pooling.cpp
+++ b/core/conversion/converters/impl/pooling.cpp
@@ -317,7 +317,14 @@ auto pooling_registrations TRTORCH_UNUSED =
 
                  auto creator = new plugins::InterpolatePluginCreator();
                  auto plugin = creator->createPlugin(
-                     "adaptive_pool2d", in_shape, out_shape, out_size, {}, std::string("adaptive_pool2d"), false, false);
+                     "adaptive_pool2d",
+                     in_shape,
+                     out_shape,
+                     out_size,
+                     {},
+                     std::string("adaptive_pool2d"),
+                     false,
+                     false);
 
                  auto pooling_layer =
                      ctx->net->addPluginV2(reinterpret_cast<nvinfer1::ITensor* const*>(&in), 1, *plugin);

--- a/core/conversion/converters/impl/pooling.cpp
+++ b/core/conversion/converters/impl/pooling.cpp
@@ -317,7 +317,7 @@ auto pooling_registrations TRTORCH_UNUSED =
 
                  auto creator = new plugins::InterpolatePluginCreator();
                  auto plugin = creator->createPlugin(
-                     "adaptive_pool2d", in_shape, out_shape, out_size, std::string("adaptive_pool2d"), false);
+                     "adaptive_pool2d", in_shape, out_shape, out_size, {}, std::string("adaptive_pool2d"), false, false);
 
                  auto pooling_layer =
                      ctx->net->addPluginV2(reinterpret_cast<nvinfer1::ITensor* const*>(&in), 1, *plugin);

--- a/tests/core/conversion/converters/test_interpolate.cpp
+++ b/tests/core/conversion/converters/test_interpolate.cpp
@@ -4,491 +4,330 @@
 #include "tests/util/util.h"
 #include "torch/csrc/jit/ir/irparser.h"
 
-TEST(Converters, ATenUpsampleNearest1dOutputSizeConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=10]()
-        %3 : int[] = prim::ListConstruct(%2)
-        %4 : None = prim::Constant()
-        %5 : Tensor = aten::upsample_nearest1d(%0, %3, %4)
-        return (%5))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
 
-  // Input Tensor needs to be 3D for TensorRT upsample_nearest1d
-  auto in = at::randint(1, 10, {10, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleNearest1dScaleFactorConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %1 : int = prim::Constant[value=8]()
-        %2 : int[] = prim::ListConstruct(%1)
-        %3 : float = prim::Constant[value=4.0]()
-        %5 : Tensor = aten::upsample_nearest1d(%0, %2, %3)
-        return (%5))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 3D for TensorRT upsample_nearest1d
-  auto in = at::randint(1, 10, {10, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleNearest2dOutputSizeConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=10]()
-        %3 : int[] = prim::ListConstruct(%2, %2)
-        %4 : None = prim::Constant()
-        %5 : Tensor = aten::upsample_nearest2d(%0, %3, %4, %4)
-        return (%5))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 4D for TensorRT upsample_nearest2d
-  auto in = at::randint(1, 10, {10, 2, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleNearest2dScaleFactorConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=8]()
-        %3 : int[] = prim::ListConstruct(%2, %2)
-        %4 : float = prim::Constant[value=4.0]()
-        %5 : Tensor = aten::upsample_nearest2d(%0, %3, %4, %4)
-        return (%5))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 4D for TensorRT upsample_nearest2d
-  auto in = at::randint(1, 10, {10, 2, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleNearest3dOutputSizeConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=10]()
-        %3 : int[] = prim::ListConstruct(%2, %2, %2)
-        %4 : None = prim::Constant()
-        %5 : Tensor = aten::upsample_nearest3d(%0, %3, %4, %4, %4)
-        return (%5))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 5D for TensorRT upsample_nearest3d
-  auto in = at::randint(1, 10, {10, 2, 2, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleNearest3dScaleFactorConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=8]()
-        %3 : int[] = prim::ListConstruct(%2, %2, %2)
-        %4 : float = prim::Constant[value=4.0]()
-        %5 : Tensor = aten::upsample_nearest3d(%0, %3, %4, %4, %4)
-        return (%5))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 5D for TensorRT upsample_nearest3d
-  auto in = at::randint(1, 10, {10, 2, 2, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleLinear1dOutputSizeWithAlignCornersConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=10]()
-        %3 : int[] = prim::ListConstruct(%2)
-        %4 : bool = prim::Constant[value=1]()
-        %5 : None = prim::Constant()
-        %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %5)
-        return (%6))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 3D for TensorRT upsample_linear1d
-  auto in = at::randint(1, 10, {10, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleLinear1dOutputSizeWithoutAlignCornersConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=10]()
-        %3 : int[] = prim::ListConstruct(%2)
-        %4 : bool = prim::Constant[value=0]()
-        %5 : None = prim::Constant()
-        %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %5)
-        return (%6))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 3D for TensorRT upsample_linear1d
-  auto in = at::randint(1, 10, {10, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleLinear1dScaleFactorWithoutAlignCornersConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=8]()
-        %3 : int[] = prim::ListConstruct(%2)
-        %4 : bool = prim::Constant[value=0]()
-        %5 : float = prim::Constant[value=4.0]()
-        %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %5)
-        return (%6))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 3D for TensorRT upsample_linear1d
-  auto in = at::randint(1, 10, {10, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleBilinear2dOutputSizeWithAlignCornersConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=10]()
-        %3 : int[] = prim::ListConstruct(%2, %2)
-        %4 : bool = prim::Constant[value=1]()
-        %5 : None = prim::Constant()
-        %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
-        return (%6))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 4D for TensorRT upsample_bilinear2d
-  auto in = at::randint(1, 10, {10, 2, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleBilinear2dOutputSizeWithoutAlignCornersConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=10]()
-        %3 : int[] = prim::ListConstruct(%2, %2)
-        %4 : bool = prim::Constant[value=0]()
-        %5 : None = prim::Constant()
-        %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
-        return (%6))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 4D for TensorRT upsample_bilinear2d
-  auto in = at::randint(1, 10, {10, 2, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleBilinear2dScaleFactorWithoutAlignCornersConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=8]()
-        %3 : int[] = prim::ListConstruct(%2, %2)
-        %4 : bool = prim::Constant[value=0]()
-        %5 : float = prim::Constant[value=4.0]()
-        %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
-        return (%6))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 4D for TensorRT upsample_bilinear2d
-  auto in = at::randint(1, 10, {10, 2, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleTrilinear3dOutputSizeWithAlignCornersConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=10]()
-        %3 : int[] = prim::ListConstruct(%2, %2, %2)
-        %4 : bool = prim::Constant[value=1]()
-        %5 : None = prim::Constant()
-        %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %5, %5, %5)
-        return (%6))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 5D for TensorRT upsample_trilinear3d
-  auto in = at::randint(1, 10, {10, 2, 2, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleTrilinear3dOutputSizeWithoutAlignCornersConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=10]()
-        %3 : int[] = prim::ListConstruct(%2, %2, %2)
-        %4 : bool = prim::Constant[value=0]()
-        %5 : None = prim::Constant()
-        %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %5, %5, %5)
-        return (%6))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 5D for TensorRT upsample_trilinear3d
-  auto in = at::randint(1, 10, {10, 2, 2, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
-
-TEST(Converters, ATenUpsampleTrilinear3dScaleFactorWithoutAlignCornersConvertsCorrectly) {
-  const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %2 : int = prim::Constant[value=8]()
-        %3 : int[] = prim::ListConstruct(%2, %2, %2)
-        %4 : bool = prim::Constant[value=0]()
-        %5 : float = prim::Constant[value=4.0]()
-        %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %5, %5, %5)
-        return (%6))IR";
-
-  auto g = std::make_shared<torch::jit::Graph>();
-
-  torch::jit::parseIR(graph, &*g);
-
-  // Input Tensor needs to be 5D for TensorRT upsample_trilinear3d
-  auto in = at::randint(1, 10, {10, 2, 2, 2, 2}, {at::kCUDA});
-
-  auto jit_in = at::clone(in);
-  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
-
-  auto trt_in = at::clone(in);
-  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
-  auto trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-
-  trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});
-  trt = trt_results[0].reshape(jit_results[0].sizes());
-  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
-}
+#define ATEN_UPSAMPLE_TESTS(name, graph_src, input_shape)                                   \
+  TEST(Converters, name##StaticConvertsCorrectly) {                                         \
+    const auto graph = graph_src;                                                           \
+                                                                                            \
+    auto g = std::make_shared<torch::jit::Graph>();                                         \
+    torch::jit::parseIR(graph, &*g);                                                        \
+                                                                                            \
+    auto in = at::randint(1, 10, input_shape, {at::kCUDA});                                 \
+    auto jit_in = at::clone(in);                                                            \
+    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});             \
+    auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});                 \
+                                                                                            \
+    auto trt_in = at::clone(in);                                                            \
+    params = trtorch::core::conversion::get_named_params(g->inputs(), {});                  \
+                                                                                            \
+    auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});           \
+    auto trt = trt_results[0].reshape(jit_results[0].sizes());                              \
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));              \
+  }                                                                                         \
+                                                                                            \
+  TEST(Converters, name##DynamicConvertsCorrectly) {                                        \
+    const auto graph = graph_src;                                                           \
+                                                                                            \
+    auto g = std::make_shared<torch::jit::Graph>();                                         \
+    torch::jit::parseIR(graph, &*g);                                                        \
+                                                                                            \
+    auto in = at::randint(1, 10, input_shape, {at::kCUDA});                                 \
+    auto jit_in = at::clone(in);                                                            \
+    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});             \
+    auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});                 \
+                                                                                            \
+    auto trt_in = at::clone(in);                                                            \
+    params = trtorch::core::conversion::get_named_params(g->inputs(), {});                  \
+                                                                                            \
+    auto trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});    \
+    auto trt = trt_results[0].reshape(jit_results[0].sizes());                              \
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));              \
+  }
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest1dOutputSize,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=10]()
+      %3 : int[] = prim::ListConstruct(%2)
+      %4 : None = prim::Constant()
+      %5 : Tensor = aten::upsample_nearest1d(%0, %3, %4)
+      return (%5))IR",
+  std::vector<int64_t>({10, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest1dScales,
+  R"IR(
+    graph(%0 : Tensor):
+      %1 : int = prim::Constant[value=8]()
+      %2 : int[] = prim::ListConstruct(%1)
+      %3 : float = prim::Constant[value=4.0]()
+      %5 : Tensor = aten::upsample_nearest1d(%0, %2, %3)
+      return (%5))IR",
+  std::vector<int64_t>({10, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest1dVecScaleFactors,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : None = prim::Constant()
+      %3 : float = prim::Constant[value=4.0]()
+      %4 : float[] = prim::ListConstruct(%3)
+      %5 : Tensor = aten::upsample_nearest1d(%0, %2, %4)
+      return (%5))IR",
+  std::vector<int64_t>({10, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest2dOutputSize,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=10]()
+      %3 : int[] = prim::ListConstruct(%2, %2)
+      %4 : None = prim::Constant()
+      %5 : Tensor = aten::upsample_nearest2d(%0, %3, %4, %4)
+      return (%5))IR",
+  std::vector<int64_t>({10, 2, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest2dScales,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=8]()
+      %3 : int[] = prim::ListConstruct(%2, %2)
+      %4 : float = prim::Constant[value=4.0]()
+      %5 : Tensor = aten::upsample_nearest2d(%0, %3, %4, %4)
+      return (%5))IR",
+  std::vector<int64_t>({10, 2, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest2dVecScaleFactors,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : None = prim::Constant()
+      %3 : float = prim::Constant[value=4.0]()
+      %4 : float[] = prim::ListConstruct(%3, %3)
+      %5 : Tensor = aten::upsample_nearest2d(%0, %2, %4)
+      return (%5))IR",
+  std::vector<int64_t>({10, 2, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest3dOutputSize,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=10]()
+      %3 : int[] = prim::ListConstruct(%2, %2, %2)
+      %4 : None = prim::Constant()
+      %5 : Tensor = aten::upsample_nearest3d(%0, %3, %4, %4, %4)
+      return (%5))IR",
+  std::vector<int64_t>({10, 2, 2, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest3dScales,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=8]()
+      %3 : int[] = prim::ListConstruct(%2, %2, %2)
+      %4 : float = prim::Constant[value=4.0]()
+      %5 : Tensor = aten::upsample_nearest3d(%0, %3, %4, %4, %4)
+      return (%5))IR",
+  std::vector<int64_t>({10, 2, 2, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest3dVecScaleFactors,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : None = prim::Constant()
+      %3 : float = prim::Constant[value=4.0]()
+      %4 : float[] = prim::ListConstruct(%3, %3, %3)
+      %5 : Tensor = aten::upsample_nearest3d(%0, %2, %4)
+      return (%5))IR",
+  std::vector<int64_t>({10, 2, 2, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dOutputSizeWithAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=10]()
+      %3 : int[] = prim::ListConstruct(%2)
+      %4 : bool = prim::Constant[value=1]()
+      %5 : None = prim::Constant()
+      %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %5)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dOutputSizeWithoutAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=10]()
+      %3 : int[] = prim::ListConstruct(%2)
+      %4 : bool = prim::Constant[value=0]()
+      %5 : None = prim::Constant()
+      %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %5)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dScalesWithoutAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=8]()
+      %3 : int[] = prim::ListConstruct(%2)
+      %4 : bool = prim::Constant[value=0]()
+      %5 : float = prim::Constant[value=4.0]()
+      %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %5)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2}));
+
+// ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dScalesWithAlignCorners,
+//   R"IR(
+//     graph(%0 : Tensor):
+//       %2 : int = prim::Constant[value=8]()
+//       %3 : int[] = prim::ListConstruct(%2)
+//       %4 : bool = prim::Constant[value=1]()
+//       %5 : float = prim::Constant[value=4.0]()
+//       %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %5)
+//       return (%6))IR",
+//   std::vector<int64_t>({10, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dVecScaleFactorsWithoutAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %3 : None = prim::Constant()
+      %4 : bool = prim::Constant[value=0]()
+      %5 : float = prim::Constant[value=4.0]()
+      %6 : float[] = prim::ListConstruct(%5)
+      %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %6)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2}));
+
+// ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dVecScaleFactorsWithAlignCorners,
+  // R"IR(
+  //   graph(%0 : Tensor):
+  //     %3 : None = prim::Constant()
+  //     %4 : bool = prim::Constant[value=1]()
+  //     %5 : float = prim::Constant[value=4.0]()
+  //     %6 : float[] = prim::ListConstruct(%5)
+  //     %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %6)
+  //     return (%6))IR",
+  // std::vector<int64_t>({10, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dOutputSizeWithAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=10]()
+      %3 : int[] = prim::ListConstruct(%2, %2)
+      %4 : bool = prim::Constant[value=1]()
+      %5 : None = prim::Constant()
+      %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dOutputSizeWithoutAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=10]()
+      %3 : int[] = prim::ListConstruct(%2, %2)
+      %4 : bool = prim::Constant[value=0]()
+      %5 : None = prim::Constant()
+      %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dScalesWithoutAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=8]()
+      %3 : int[] = prim::ListConstruct(%2, %2)
+      %4 : bool = prim::Constant[value=0]()
+      %5 : float = prim::Constant[value=4.0]()
+      %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2, 2}));
+
+// ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dScalesWithAlignCorners,
+  // R"IR(
+  //   graph(%0 : Tensor):
+  //     %2 : int = prim::Constant[value=8]()
+  //     %3 : int[] = prim::ListConstruct(%2, %2)
+  //     %4 : bool = prim::Constant[value=1]()
+  //     %5 : float = prim::Constant[value=4.0]()
+  //     %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
+  //     return (%6))IR",
+//   std::vector<int64_t>({10, 2, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dVecScaleFactorsWithoutAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %3 : None = prim::Constant()
+      %4 : bool = prim::Constant[value=0]()
+      %5 : float = prim::Constant[value=4.0]()
+      %6 : float[] = prim::ListConstruct(%5, %5)
+      %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %6)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2, 2}));
+
+// ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dVecScaleFactorsWithAlignCorners,
+//  R"IR(
+//   graph(%0 : Tensor):
+//     %3 : None = prim::Constant()
+//     %4 : bool = prim::Constant[value=1]()
+//     %5 : float = prim::Constant[value=4.0]()
+//     %6 : float[] = prim::ListConstruct(%5, %5)
+//     %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %6)
+//     return (%6))IR",
+// std::vector<int64_t>({10, 2, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dOutputSizeWithAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=10]()
+      %3 : int[] = prim::ListConstruct(%2, %2, %2)
+      %4 : bool = prim::Constant[value=1]()
+      %5 : None = prim::Constant()
+      %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %5, %5, %5)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dOutputSizeWithoutAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=10]()
+      %3 : int[] = prim::ListConstruct(%2, %2, %2)
+      %4 : bool = prim::Constant[value=0]()
+      %5 : None = prim::Constant()
+      %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %5, %5, %5)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dScalesWithoutAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=8]()
+      %3 : int[] = prim::ListConstruct(%2, %2, %2)
+      %4 : bool = prim::Constant[value=0]()
+      %5 : float = prim::Constant[value=4.0]()
+      %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %5, %5, %5)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2, 2, 2}));
+
+// ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dScalesWithAlignCorners,
+  // R"IR(
+  //   graph(%0 : Tensor):
+  //     %2 : int = prim::Constant[value=8]()
+  //     %3 : int[] = prim::ListConstruct(%2, %2)
+  //     %4 : bool = prim::Constant[value=1]()
+  //     %5 : float = prim::Constant[value=4.0]()
+  //     %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
+  //     return (%6))IR",
+//   std::vector<int64_t>({10, 2, 2, 2}));
+
+ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dVecScaleFactorsWithoutAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %3 : None = prim::Constant()
+      %4 : bool = prim::Constant[value=0]()
+      %5 : float = prim::Constant[value=4.0]()
+      %6 : float[] = prim::ListConstruct(%5, %5, %5)
+      %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %6)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2, 2, 2}));
+
+// ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dVecScaleFactorsWithAlignCorners,
+//  R"IR(
+//   graph(%0 : Tensor):
+//     %3 : None = prim::Constant()
+//     %4 : bool = prim::Constant[value=1]()
+//     %5 : float = prim::Constant[value=4.0]()
+//     %6 : float[] = prim::ListConstruct(%5, %5, %5)
+//     %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %6)
+//     return (%6))IR",
+// std::vector<int64_t>({10, 2, 2, 2}));

--- a/tests/core/conversion/converters/test_interpolate.cpp
+++ b/tests/core/conversion/converters/test_interpolate.cpp
@@ -4,158 +4,167 @@
 #include "tests/util/util.h"
 #include "torch/csrc/jit/ir/irparser.h"
 
-
-#define ATEN_INTERPOLATE_TESTS(name, graph_src, input_shape)                                \
-  TEST(Converters, name##StaticConvertsCorrectly) {                                         \
-    const auto graph = graph_src;                                                           \
-                                                                                            \
-    auto g = std::make_shared<torch::jit::Graph>();                                         \
-    torch::jit::parseIR(graph, &*g);                                                        \
-                                                                                            \
-    auto in = at::randint(1, 10, input_shape, {at::kCUDA});                                 \
-    auto jit_in = at::clone(in);                                                            \
-    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});             \
-    auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});                 \
-                                                                                            \
-    auto trt_in = at::clone(in);                                                            \
-    params = trtorch::core::conversion::get_named_params(g->inputs(), {});                  \
-                                                                                            \
-    auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});           \
-    auto trt = trt_results[0].reshape(jit_results[0].sizes());                              \
-    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));              \
-  }                                                                                         \
-                                                                                            \
-  TEST(Converters, name##DynamicConvertsCorrectly) {                                        \
-    const auto graph = graph_src;                                                           \
-                                                                                            \
-    auto g = std::make_shared<torch::jit::Graph>();                                         \
-    torch::jit::parseIR(graph, &*g);                                                        \
-                                                                                            \
-    auto in = at::randint(1, 10, input_shape, {at::kCUDA});                                 \
-    auto jit_in = at::clone(in);                                                            \
-    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});             \
-    auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});                 \
-                                                                                            \
-    auto trt_in = at::clone(in);                                                            \
-    params = trtorch::core::conversion::get_named_params(g->inputs(), {});                  \
-                                                                                            \
-    auto trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in});    \
-    auto trt = trt_results[0].reshape(jit_results[0].sizes());                              \
-    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));              \
+#define ATEN_INTERPOLATE_TESTS(name, graph_src, input_shape)                             \
+  TEST(Converters, name##StaticConvertsCorrectly) {                                      \
+    const auto graph = graph_src;                                                        \
+                                                                                         \
+    auto g = std::make_shared<torch::jit::Graph>();                                      \
+    torch::jit::parseIR(graph, &*g);                                                     \
+                                                                                         \
+    auto in = at::randint(1, 10, input_shape, {at::kCUDA});                              \
+    auto jit_in = at::clone(in);                                                         \
+    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});          \
+    auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});              \
+                                                                                         \
+    auto trt_in = at::clone(in);                                                         \
+    params = trtorch::core::conversion::get_named_params(g->inputs(), {});               \
+                                                                                         \
+    auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});        \
+    auto trt = trt_results[0].reshape(jit_results[0].sizes());                           \
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));           \
+  }                                                                                      \
+                                                                                         \
+  TEST(Converters, name##DynamicConvertsCorrectly) {                                     \
+    const auto graph = graph_src;                                                        \
+                                                                                         \
+    auto g = std::make_shared<torch::jit::Graph>();                                      \
+    torch::jit::parseIR(graph, &*g);                                                     \
+                                                                                         \
+    auto in = at::randint(1, 10, input_shape, {at::kCUDA});                              \
+    auto jit_in = at::clone(in);                                                         \
+    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});          \
+    auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});              \
+                                                                                         \
+    auto trt_in = at::clone(in);                                                         \
+    params = trtorch::core::conversion::get_named_params(g->inputs(), {});               \
+                                                                                         \
+    auto trt_results = trtorch::tests::util::RunGraphEngineDynamic(g, params, {trt_in}); \
+    auto trt = trt_results[0].reshape(jit_results[0].sizes());                           \
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));           \
   }
 
-#define ATEN_INTERPOLATE_STATIC_ONLY_TEST(name, graph_src, input_shape)                     \
-  TEST(Converters, name##StaticConvertsCorrectly) {                                         \
-    const auto graph = graph_src;                                                           \
-                                                                                            \
-    auto g = std::make_shared<torch::jit::Graph>();                                         \
-    torch::jit::parseIR(graph, &*g);                                                        \
-                                                                                            \
-    auto in = at::randint(1, 10, input_shape, {at::kCUDA});                                 \
-    auto jit_in = at::clone(in);                                                            \
-    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});             \
-    auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});                 \
-                                                                                            \
-    auto trt_in = at::clone(in);                                                            \
-    params = trtorch::core::conversion::get_named_params(g->inputs(), {});                  \
-                                                                                            \
-    auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});           \
-    auto trt = trt_results[0].reshape(jit_results[0].sizes());                              \
-    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));              \
+#define ATEN_INTERPOLATE_STATIC_ONLY_TEST(name, graph_src, input_shape)           \
+  TEST(Converters, name##StaticConvertsCorrectly) {                               \
+    const auto graph = graph_src;                                                 \
+                                                                                  \
+    auto g = std::make_shared<torch::jit::Graph>();                               \
+    torch::jit::parseIR(graph, &*g);                                              \
+                                                                                  \
+    auto in = at::randint(1, 10, input_shape, {at::kCUDA});                       \
+    auto jit_in = at::clone(in);                                                  \
+    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});   \
+    auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});       \
+                                                                                  \
+    auto trt_in = at::clone(in);                                                  \
+    params = trtorch::core::conversion::get_named_params(g->inputs(), {});        \
+                                                                                  \
+    auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in}); \
+    auto trt = trt_results[0].reshape(jit_results[0].sizes());                    \
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));    \
   }
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest1dOutputSize,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleNearest1dOutputSize,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
       %3 : int[] = prim::ListConstruct(%2)
       %4 : None = prim::Constant()
       %5 : Tensor = aten::upsample_nearest1d(%0, %3, %4)
       return (%5))IR",
-  std::vector<int64_t>({10, 2, 2}));
+    std::vector<int64_t>({10, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest1dScales,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleNearest1dScales,
+    R"IR(
     graph(%0 : Tensor):
       %1 : int = prim::Constant[value=8]()
       %2 : int[] = prim::ListConstruct(%1)
       %3 : float = prim::Constant[value=4.0]()
       %5 : Tensor = aten::upsample_nearest1d(%0, %2, %3)
       return (%5))IR",
-  std::vector<int64_t>({10, 2, 2}));
+    std::vector<int64_t>({10, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest1dVecScaleFactors,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleNearest1dVecScaleFactors,
+    R"IR(
     graph(%0 : Tensor):
       %2 : None = prim::Constant()
       %3 : float = prim::Constant[value=4.0]()
       %4 : float[] = prim::ListConstruct(%3)
       %5 : Tensor = aten::upsample_nearest1d(%0, %2, %4)
       return (%5))IR",
-  std::vector<int64_t>({10, 2, 2}));
+    std::vector<int64_t>({10, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest2dOutputSize,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleNearest2dOutputSize,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
       %3 : int[] = prim::ListConstruct(%2, %2)
       %4 : None = prim::Constant()
       %5 : Tensor = aten::upsample_nearest2d(%0, %3, %4, %4)
       return (%5))IR",
-  std::vector<int64_t>({10, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest2dScales,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleNearest2dScales,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=8]()
       %3 : int[] = prim::ListConstruct(%2, %2)
       %4 : float = prim::Constant[value=4.0]()
       %5 : Tensor = aten::upsample_nearest2d(%0, %3, %4, %4)
       return (%5))IR",
-  std::vector<int64_t>({10, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest2dVecScaleFactors,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleNearest2dVecScaleFactors,
+    R"IR(
     graph(%0 : Tensor):
       %2 : None = prim::Constant()
       %3 : float = prim::Constant[value=4.0]()
       %4 : float[] = prim::ListConstruct(%3, %3)
       %5 : Tensor = aten::upsample_nearest2d(%0, %2, %4)
       return (%5))IR",
-  std::vector<int64_t>({10, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest3dOutputSize,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleNearest3dOutputSize,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
       %3 : int[] = prim::ListConstruct(%2, %2, %2)
       %4 : None = prim::Constant()
       %5 : Tensor = aten::upsample_nearest3d(%0, %3, %4, %4, %4)
       return (%5))IR",
-  std::vector<int64_t>({10, 2, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest3dScales,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleNearest3dScales,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=8]()
       %3 : int[] = prim::ListConstruct(%2, %2, %2)
       %4 : float = prim::Constant[value=4.0]()
       %5 : Tensor = aten::upsample_nearest3d(%0, %3, %4, %4, %4)
       return (%5))IR",
-  std::vector<int64_t>({10, 2, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest3dVecScaleFactors,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleNearest3dVecScaleFactors,
+    R"IR(
     graph(%0 : Tensor):
       %2 : None = prim::Constant()
       %3 : float = prim::Constant[value=4.0]()
       %4 : float[] = prim::ListConstruct(%3, %3, %3)
       %5 : Tensor = aten::upsample_nearest3d(%0, %2, %4)
       return (%5))IR",
-  std::vector<int64_t>({10, 2, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleLinear1dOutputSizeWithAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleLinear1dOutputSizeWithAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
       %3 : int[] = prim::ListConstruct(%2)
@@ -163,10 +172,11 @@ ATEN_INTERPOLATE_TESTS(ATenUpsampleLinear1dOutputSizeWithAlignCorners,
       %5 : None = prim::Constant()
       %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %5)
       return (%6))IR",
-  std::vector<int64_t>({10, 2, 2}));
+    std::vector<int64_t>({10, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleLinear1dOutputSizeWithoutAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleLinear1dOutputSizeWithoutAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
       %3 : int[] = prim::ListConstruct(%2)
@@ -174,10 +184,11 @@ ATEN_INTERPOLATE_TESTS(ATenUpsampleLinear1dOutputSizeWithoutAlignCorners,
       %5 : None = prim::Constant()
       %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %5)
       return (%6))IR",
-  std::vector<int64_t>({10, 2, 2}));
+    std::vector<int64_t>({10, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleLinear1dScalesWithoutAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleLinear1dScalesWithoutAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=8]()
       %3 : int[] = prim::ListConstruct(%2)
@@ -185,10 +196,11 @@ ATEN_INTERPOLATE_TESTS(ATenUpsampleLinear1dScalesWithoutAlignCorners,
       %5 : float = prim::Constant[value=4.0]()
       %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %5)
       return (%6))IR",
-  std::vector<int64_t>({10, 2, 2}));
+    std::vector<int64_t>({10, 2, 2}));
 
-ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleLinear1dScalesWithAlignCorners,
-   R"IR(
+ATEN_INTERPOLATE_STATIC_ONLY_TEST(
+    ATenUpsampleLinear1dScalesWithAlignCorners,
+    R"IR(
      graph(%0 : Tensor):
        %2 : int = prim::Constant[value=8]()
        %3 : int[] = prim::ListConstruct(%2)
@@ -196,10 +208,11 @@ ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleLinear1dScalesWithAlignCorners,
        %5 : float = prim::Constant[value=4.0]()
        %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %5)
        return (%6))IR",
-std::vector<int64_t>({10, 2, 2}));
+    std::vector<int64_t>({10, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleLinear1dVecScaleFactorsWithoutAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleLinear1dVecScaleFactorsWithoutAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %3 : None = prim::Constant()
       %4 : bool = prim::Constant[value=0]()
@@ -207,10 +220,11 @@ ATEN_INTERPOLATE_TESTS(ATenUpsampleLinear1dVecScaleFactorsWithoutAlignCorners,
       %6 : float[] = prim::ListConstruct(%5)
       %7 : Tensor = aten::upsample_linear1d(%0, %3, %4, %6)
       return (%7))IR",
-  std::vector<int64_t>({10, 2, 2}));
+    std::vector<int64_t>({10, 2, 2}));
 
-ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleLinear1dVecScaleFactorsWithAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_STATIC_ONLY_TEST(
+    ATenUpsampleLinear1dVecScaleFactorsWithAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
      %3 : None = prim::Constant()
      %4 : bool = prim::Constant[value=1]()
@@ -218,10 +232,11 @@ ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleLinear1dVecScaleFactorsWithAlignCo
      %6 : float[] = prim::ListConstruct(%5)
      %7 : Tensor = aten::upsample_linear1d(%0, %3, %4, %6)
      return (%7))IR",
-  std::vector<int64_t>({10, 2, 2}));
+    std::vector<int64_t>({10, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleBilinear2dOutputSizeWithAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleBilinear2dOutputSizeWithAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
       %3 : int[] = prim::ListConstruct(%2, %2)
@@ -229,10 +244,11 @@ ATEN_INTERPOLATE_TESTS(ATenUpsampleBilinear2dOutputSizeWithAlignCorners,
       %5 : None = prim::Constant()
       %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
       return (%6))IR",
-  std::vector<int64_t>({10, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleBilinear2dOutputSizeWithoutAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleBilinear2dOutputSizeWithoutAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
       %3 : int[] = prim::ListConstruct(%2, %2)
@@ -240,10 +256,11 @@ ATEN_INTERPOLATE_TESTS(ATenUpsampleBilinear2dOutputSizeWithoutAlignCorners,
       %5 : None = prim::Constant()
       %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
       return (%6))IR",
-  std::vector<int64_t>({10, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleBilinear2dScalesWithoutAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleBilinear2dScalesWithoutAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=8]()
       %3 : int[] = prim::ListConstruct(%2, %2)
@@ -251,10 +268,11 @@ ATEN_INTERPOLATE_TESTS(ATenUpsampleBilinear2dScalesWithoutAlignCorners,
       %5 : float = prim::Constant[value=4.0]()
       %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
       return (%6))IR",
-  std::vector<int64_t>({10, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleBilinear2dScalesWithAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_STATIC_ONLY_TEST(
+    ATenUpsampleBilinear2dScalesWithAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=8]()
       %3 : int[] = prim::ListConstruct(%2, %2)
@@ -262,10 +280,11 @@ ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleBilinear2dScalesWithAlignCorners,
       %5 : float = prim::Constant[value=4.0]()
       %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
       return (%6))IR",
-  std::vector<int64_t>({10, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleBilinear2dVecScaleFactorsWithoutAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleBilinear2dVecScaleFactorsWithoutAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %3 : None = prim::Constant()
       %4 : bool = prim::Constant[value=0]()
@@ -273,10 +292,11 @@ ATEN_INTERPOLATE_TESTS(ATenUpsampleBilinear2dVecScaleFactorsWithoutAlignCorners,
       %6 : float[] = prim::ListConstruct(%5, %5)
       %7 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %6)
       return (%7))IR",
-  std::vector<int64_t>({10, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleBilinear2dVecScaleFactorsWithAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_STATIC_ONLY_TEST(
+    ATenUpsampleBilinear2dVecScaleFactorsWithAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %3 : None = prim::Constant()
       %4 : bool = prim::Constant[value=1]()
@@ -284,10 +304,11 @@ ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleBilinear2dVecScaleFactorsWithAlign
       %6 : float[] = prim::ListConstruct(%5, %5)
       %7 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %6)
       return (%7))IR",
-  std::vector<int64_t>({10, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleTrilinear3dOutputSizeWithAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleTrilinear3dOutputSizeWithAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
       %3 : int[] = prim::ListConstruct(%2, %2, %2)
@@ -295,10 +316,11 @@ ATEN_INTERPOLATE_TESTS(ATenUpsampleTrilinear3dOutputSizeWithAlignCorners,
       %5 : None = prim::Constant()
       %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %5, %5, %5)
       return (%6))IR",
-  std::vector<int64_t>({10, 2, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleTrilinear3dOutputSizeWithoutAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleTrilinear3dOutputSizeWithoutAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
       %3 : int[] = prim::ListConstruct(%2, %2, %2)
@@ -306,10 +328,11 @@ ATEN_INTERPOLATE_TESTS(ATenUpsampleTrilinear3dOutputSizeWithoutAlignCorners,
       %5 : None = prim::Constant()
       %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %5, %5, %5)
       return (%6))IR",
-  std::vector<int64_t>({10, 2, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleTrilinear3dScalesWithoutAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleTrilinear3dScalesWithoutAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=8]()
       %3 : int[] = prim::ListConstruct(%2, %2, %2)
@@ -317,10 +340,11 @@ ATEN_INTERPOLATE_TESTS(ATenUpsampleTrilinear3dScalesWithoutAlignCorners,
       %5 : float = prim::Constant[value=4.0]()
       %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %5, %5, %5)
       return (%6))IR",
-  std::vector<int64_t>({10, 2, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleTrilinear3dScalesWithAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_STATIC_ONLY_TEST(
+    ATenUpsampleTrilinear3dScalesWithAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=8]()
       %3 : int[] = prim::ListConstruct(%2, %2, %2)
@@ -328,10 +352,11 @@ ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleTrilinear3dScalesWithAlignCorners,
       %5 : float = prim::Constant[value=4.0]()
       %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %5, %5, %5)
       return (%6))IR",
-  std::vector<int64_t>({10, 2, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_INTERPOLATE_TESTS(ATenUpsampleTrilinear3dVecScaleFactorsWithoutAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_TESTS(
+    ATenUpsampleTrilinear3dVecScaleFactorsWithoutAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %3 : None = prim::Constant()
       %4 : bool = prim::Constant[value=0]()
@@ -339,10 +364,11 @@ ATEN_INTERPOLATE_TESTS(ATenUpsampleTrilinear3dVecScaleFactorsWithoutAlignCorners
       %6 : float[] = prim::ListConstruct(%5, %5, %5)
       %7 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %6)
       return (%7))IR",
-  std::vector<int64_t>({10, 2, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleTrilinear3dVecScaleFactorsWithAlignCorners,
-  R"IR(
+ATEN_INTERPOLATE_STATIC_ONLY_TEST(
+    ATenUpsampleTrilinear3dVecScaleFactorsWithAlignCorners,
+    R"IR(
     graph(%0 : Tensor):
       %3 : None = prim::Constant()
       %4 : bool = prim::Constant[value=1]()
@@ -350,4 +376,4 @@ ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleTrilinear3dVecScaleFactorsWithAlig
       %6 : float[] = prim::ListConstruct(%5, %5, %5)
       %7 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %6)
       return (%7))IR",
-  std::vector<int64_t>({10, 2, 2, 2, 2}));
+    std::vector<int64_t>({10, 2, 2, 2, 2}));

--- a/tests/core/conversion/converters/test_interpolate.cpp
+++ b/tests/core/conversion/converters/test_interpolate.cpp
@@ -5,7 +5,7 @@
 #include "torch/csrc/jit/ir/irparser.h"
 
 
-#define ATEN_UPSAMPLE_TESTS(name, graph_src, input_shape)                                   \
+#define ATEN_INTERPOLATE_TESTS(name, graph_src, input_shape)                                \
   TEST(Converters, name##StaticConvertsCorrectly) {                                         \
     const auto graph = graph_src;                                                           \
                                                                                             \
@@ -44,7 +44,27 @@
     ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));              \
   }
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest1dOutputSize,
+#define ATEN_INTERPOLATE_STATIC_ONLY_TEST(name, graph_src, input_shape)                     \
+  TEST(Converters, name##StaticConvertsCorrectly) {                                         \
+    const auto graph = graph_src;                                                           \
+                                                                                            \
+    auto g = std::make_shared<torch::jit::Graph>();                                         \
+    torch::jit::parseIR(graph, &*g);                                                        \
+                                                                                            \
+    auto in = at::randint(1, 10, input_shape, {at::kCUDA});                                 \
+    auto jit_in = at::clone(in);                                                            \
+    auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});             \
+    auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});                 \
+                                                                                            \
+    auto trt_in = at::clone(in);                                                            \
+    params = trtorch::core::conversion::get_named_params(g->inputs(), {});                  \
+                                                                                            \
+    auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});           \
+    auto trt = trt_results[0].reshape(jit_results[0].sizes());                              \
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));              \
+  }
+
+ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest1dOutputSize,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
@@ -54,7 +74,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest1dOutputSize,
       return (%5))IR",
   std::vector<int64_t>({10, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest1dScales,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest1dScales,
   R"IR(
     graph(%0 : Tensor):
       %1 : int = prim::Constant[value=8]()
@@ -64,7 +84,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest1dScales,
       return (%5))IR",
   std::vector<int64_t>({10, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest1dVecScaleFactors,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest1dVecScaleFactors,
   R"IR(
     graph(%0 : Tensor):
       %2 : None = prim::Constant()
@@ -74,7 +94,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest1dVecScaleFactors,
       return (%5))IR",
   std::vector<int64_t>({10, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest2dOutputSize,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest2dOutputSize,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
@@ -84,7 +104,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest2dOutputSize,
       return (%5))IR",
   std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest2dScales,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest2dScales,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=8]()
@@ -94,7 +114,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest2dScales,
       return (%5))IR",
   std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest2dVecScaleFactors,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest2dVecScaleFactors,
   R"IR(
     graph(%0 : Tensor):
       %2 : None = prim::Constant()
@@ -104,7 +124,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest2dVecScaleFactors,
       return (%5))IR",
   std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest3dOutputSize,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest3dOutputSize,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
@@ -114,7 +134,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest3dOutputSize,
       return (%5))IR",
   std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest3dScales,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest3dScales,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=8]()
@@ -124,7 +144,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest3dScales,
       return (%5))IR",
   std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest3dVecScaleFactors,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleNearest3dVecScaleFactors,
   R"IR(
     graph(%0 : Tensor):
       %2 : None = prim::Constant()
@@ -134,7 +154,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleNearest3dVecScaleFactors,
       return (%5))IR",
   std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dOutputSizeWithAlignCorners,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleLinear1dOutputSizeWithAlignCorners,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
@@ -145,7 +165,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dOutputSizeWithAlignCorners,
       return (%6))IR",
   std::vector<int64_t>({10, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dOutputSizeWithoutAlignCorners,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleLinear1dOutputSizeWithoutAlignCorners,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
@@ -156,7 +176,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dOutputSizeWithoutAlignCorners,
       return (%6))IR",
   std::vector<int64_t>({10, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dScalesWithoutAlignCorners,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleLinear1dScalesWithoutAlignCorners,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=8]()
@@ -167,40 +187,40 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dScalesWithoutAlignCorners,
       return (%6))IR",
   std::vector<int64_t>({10, 2, 2}));
 
-// ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dScalesWithAlignCorners,
-//   R"IR(
-//     graph(%0 : Tensor):
-//       %2 : int = prim::Constant[value=8]()
-//       %3 : int[] = prim::ListConstruct(%2)
-//       %4 : bool = prim::Constant[value=1]()
-//       %5 : float = prim::Constant[value=4.0]()
-//       %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %5)
-//       return (%6))IR",
-//   std::vector<int64_t>({10, 2, 2}));
+ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleLinear1dScalesWithAlignCorners,
+   R"IR(
+     graph(%0 : Tensor):
+       %2 : int = prim::Constant[value=8]()
+       %3 : int[] = prim::ListConstruct(%2)
+       %4 : bool = prim::Constant[value=1]()
+       %5 : float = prim::Constant[value=4.0]()
+       %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %5)
+       return (%6))IR",
+std::vector<int64_t>({10, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dVecScaleFactorsWithoutAlignCorners,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleLinear1dVecScaleFactorsWithoutAlignCorners,
   R"IR(
     graph(%0 : Tensor):
       %3 : None = prim::Constant()
       %4 : bool = prim::Constant[value=0]()
       %5 : float = prim::Constant[value=4.0]()
       %6 : float[] = prim::ListConstruct(%5)
-      %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %6)
-      return (%6))IR",
+      %7 : Tensor = aten::upsample_linear1d(%0, %3, %4, %6)
+      return (%7))IR",
   std::vector<int64_t>({10, 2, 2}));
 
-// ATEN_UPSAMPLE_TESTS(ATenUpsampleLinear1dVecScaleFactorsWithAlignCorners,
-  // R"IR(
-  //   graph(%0 : Tensor):
-  //     %3 : None = prim::Constant()
-  //     %4 : bool = prim::Constant[value=1]()
-  //     %5 : float = prim::Constant[value=4.0]()
-  //     %6 : float[] = prim::ListConstruct(%5)
-  //     %6 : Tensor = aten::upsample_linear1d(%0, %3, %4, %6)
-  //     return (%6))IR",
-  // std::vector<int64_t>({10, 2, 2}));
+ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleLinear1dVecScaleFactorsWithAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+     %3 : None = prim::Constant()
+     %4 : bool = prim::Constant[value=1]()
+     %5 : float = prim::Constant[value=4.0]()
+     %6 : float[] = prim::ListConstruct(%5)
+     %7 : Tensor = aten::upsample_linear1d(%0, %3, %4, %6)
+     return (%7))IR",
+  std::vector<int64_t>({10, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dOutputSizeWithAlignCorners,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleBilinear2dOutputSizeWithAlignCorners,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
@@ -211,7 +231,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dOutputSizeWithAlignCorners,
       return (%6))IR",
   std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dOutputSizeWithoutAlignCorners,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleBilinear2dOutputSizeWithoutAlignCorners,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
@@ -222,7 +242,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dOutputSizeWithoutAlignCorners,
       return (%6))IR",
   std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dScalesWithoutAlignCorners,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleBilinear2dScalesWithoutAlignCorners,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=8]()
@@ -233,40 +253,40 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dScalesWithoutAlignCorners,
       return (%6))IR",
   std::vector<int64_t>({10, 2, 2, 2}));
 
-// ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dScalesWithAlignCorners,
-  // R"IR(
-  //   graph(%0 : Tensor):
-  //     %2 : int = prim::Constant[value=8]()
-  //     %3 : int[] = prim::ListConstruct(%2, %2)
-  //     %4 : bool = prim::Constant[value=1]()
-  //     %5 : float = prim::Constant[value=4.0]()
-  //     %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
-  //     return (%6))IR",
-//   std::vector<int64_t>({10, 2, 2, 2}));
+ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleBilinear2dScalesWithAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=8]()
+      %3 : int[] = prim::ListConstruct(%2, %2)
+      %4 : bool = prim::Constant[value=1]()
+      %5 : float = prim::Constant[value=4.0]()
+      %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dVecScaleFactorsWithoutAlignCorners,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleBilinear2dVecScaleFactorsWithoutAlignCorners,
   R"IR(
     graph(%0 : Tensor):
       %3 : None = prim::Constant()
       %4 : bool = prim::Constant[value=0]()
       %5 : float = prim::Constant[value=4.0]()
       %6 : float[] = prim::ListConstruct(%5, %5)
-      %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %6)
-      return (%6))IR",
+      %7 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %6)
+      return (%7))IR",
   std::vector<int64_t>({10, 2, 2, 2}));
 
-// ATEN_UPSAMPLE_TESTS(ATenUpsampleBilinear2dVecScaleFactorsWithAlignCorners,
-//  R"IR(
-//   graph(%0 : Tensor):
-//     %3 : None = prim::Constant()
-//     %4 : bool = prim::Constant[value=1]()
-//     %5 : float = prim::Constant[value=4.0]()
-//     %6 : float[] = prim::ListConstruct(%5, %5)
-//     %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %6)
-//     return (%6))IR",
-// std::vector<int64_t>({10, 2, 2, 2}));
+ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleBilinear2dVecScaleFactorsWithAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %3 : None = prim::Constant()
+      %4 : bool = prim::Constant[value=1]()
+      %5 : float = prim::Constant[value=4.0]()
+      %6 : float[] = prim::ListConstruct(%5, %5)
+      %7 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %6)
+      return (%7))IR",
+  std::vector<int64_t>({10, 2, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dOutputSizeWithAlignCorners,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleTrilinear3dOutputSizeWithAlignCorners,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
@@ -277,7 +297,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dOutputSizeWithAlignCorners,
       return (%6))IR",
   std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dOutputSizeWithoutAlignCorners,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleTrilinear3dOutputSizeWithoutAlignCorners,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=10]()
@@ -288,7 +308,7 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dOutputSizeWithoutAlignCorners,
       return (%6))IR",
   std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dScalesWithoutAlignCorners,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleTrilinear3dScalesWithoutAlignCorners,
   R"IR(
     graph(%0 : Tensor):
       %2 : int = prim::Constant[value=8]()
@@ -299,35 +319,35 @@ ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dScalesWithoutAlignCorners,
       return (%6))IR",
   std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-// ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dScalesWithAlignCorners,
-  // R"IR(
-  //   graph(%0 : Tensor):
-  //     %2 : int = prim::Constant[value=8]()
-  //     %3 : int[] = prim::ListConstruct(%2, %2)
-  //     %4 : bool = prim::Constant[value=1]()
-  //     %5 : float = prim::Constant[value=4.0]()
-  //     %6 : Tensor = aten::upsample_bilinear2d(%0, %3, %4, %5, %5)
-  //     return (%6))IR",
-//   std::vector<int64_t>({10, 2, 2, 2}));
+ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleTrilinear3dScalesWithAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %2 : int = prim::Constant[value=8]()
+      %3 : int[] = prim::ListConstruct(%2, %2, %2)
+      %4 : bool = prim::Constant[value=1]()
+      %5 : float = prim::Constant[value=4.0]()
+      %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %5, %5, %5)
+      return (%6))IR",
+  std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dVecScaleFactorsWithoutAlignCorners,
+ATEN_INTERPOLATE_TESTS(ATenUpsampleTrilinear3dVecScaleFactorsWithoutAlignCorners,
   R"IR(
     graph(%0 : Tensor):
       %3 : None = prim::Constant()
       %4 : bool = prim::Constant[value=0]()
       %5 : float = prim::Constant[value=4.0]()
       %6 : float[] = prim::ListConstruct(%5, %5, %5)
-      %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %6)
-      return (%6))IR",
+      %7 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %6)
+      return (%7))IR",
   std::vector<int64_t>({10, 2, 2, 2, 2}));
 
-// ATEN_UPSAMPLE_TESTS(ATenUpsampleTrilinear3dVecScaleFactorsWithAlignCorners,
-//  R"IR(
-//   graph(%0 : Tensor):
-//     %3 : None = prim::Constant()
-//     %4 : bool = prim::Constant[value=1]()
-//     %5 : float = prim::Constant[value=4.0]()
-//     %6 : float[] = prim::ListConstruct(%5, %5, %5)
-//     %6 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %6)
-//     return (%6))IR",
-// std::vector<int64_t>({10, 2, 2, 2}));
+ATEN_INTERPOLATE_STATIC_ONLY_TEST(ATenUpsampleTrilinear3dVecScaleFactorsWithAlignCorners,
+  R"IR(
+    graph(%0 : Tensor):
+      %3 : None = prim::Constant()
+      %4 : bool = prim::Constant[value=1]()
+      %5 : float = prim::Constant[value=4.0]()
+      %6 : float[] = prim::ListConstruct(%5, %5, %5)
+      %7 : Tensor = aten::upsample_trilinear3d(%0, %3, %4, %6)
+      return (%7))IR",
+  std::vector<int64_t>({10, 2, 2, 2, 2}));

--- a/tests/util/util.cpp
+++ b/tests/util/util.cpp
@@ -16,7 +16,7 @@ bool checkRtol(const at::Tensor& diff, const std::vector<at::Tensor> inputs, flo
 }
 
 bool almostEqual(const at::Tensor& a, const at::Tensor& b, float threshold) {
-  LOG_DEBUG(a << std::endl << b << std::endl);
+  LOG_GRAPH(a << std::endl << b << std::endl);
   auto a_float = a.toType(at::kFloat);
   auto b_float = b.toType(at::kFloat);
   return checkRtol(a_float - b_float, {a_float, b_float}, threshold);


### PR DESCRIPTION
# Description

This PR includes the changes in #258, does some refactoring of the test suite for interpolate and should expand coverage of the interpolate converter for the two variants of each of the currently supported resize functions (self, and vec). It should mean that we support interpolate for nearest and linear variants for all cases except when users use a type of linear upsampling, use scale factor for setting the size and set `align_corners` to true. It seems like @uni19  found that TensorRT  and PyTorch have different behavior in this case. I will check with the TRT team to see if they have observed this. Hopefully it is not a massive issue as PyTorch since 1.5 has switched to `align_corners` being false by default. As a stop gap this PR extends the interpolate plugin to handle this case, however it can only do so for static TRT engines. Currently the build time dimension calculation can only be done with `int`s where as scale factors for PyTorch are `float`s. Therefore in the case of dynamic engine for a model using [Bi/Tri]Linear interpolate with scale factor and `align_corners`=True, TRTorch will error out. Hopefully this is niche enough of a use case to not cause issues until we get a response from TensorRT. 

Fixes #290 

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project (You can use the linters)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas and hacks
- [X] I have made corresponding changes to the documentation
- [X] I have added tests to verify my fix or my feature
- [X] New and existing unit tests pass locally with my changes