### PR TITLE
Fix issue with num_to_tensor evaluator

### DIFF
--- a/core/conversion/evaluators/prim.cpp
+++ b/core/conversion/evaluators/prim.cpp
@@ -30,7 +30,7 @@ auto prim_registrations =
                     }})
         .evaluator({torch::jit::prim::NumToTensor,
                     [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
-                      return at::scalar_to_tensor(args.at(n->output(0)).IValue()->toScalar());
+                      return at::scalar_to_tensor(args.at(n->input(0)).IValue()->toScalar());
                     }})
         .evaluator({torch::jit::prim::ListUnpack,
                     [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {

--- a/tests/core/conversion/evaluators/test_prim_evaluators.cpp
+++ b/tests/core/conversion/evaluators/test_prim_evaluators.cpp
@@ -37,3 +37,19 @@ TEST(Evaluators, PrimListUnpackEvaluatesCorrectly) {
   ASSERT_TRUE(jit_results[0] == trt_results[0]);
   ASSERT_TRUE(jit_results[1] == trt_results[1]);
 }
+
+TEST(Evaluators, NumToTensorEvaluatesCorrectly) {
+  const auto graph = R"IR(
+      graph():
+        %1 : int = prim::Constant[value=3]()
+        %lu.1 : Tensor = prim::NumToTensor(%1)
+        return (%lu.1))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto jit_results = trtorch::tests::util::EvaluateGraphJIT(g, {});
+  auto trt_results = trtorch::tests::util::EvaluateGraph(g->block(), {});
+
+  ASSERT_TRUE(jit_results[0] == trt_results[0]);
+}


### PR DESCRIPTION
# Description

This fixes an issue with the `prim::num_to_tensor` evaluator where it used to be using the output as a key for the argument instead of the node input. 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes