### PR TITLE
support index=-1, and fix bug when nDims=2 or 3 in softmax

### DIFF
--- a/core/conversion/converters/impl/softmax.cpp
+++ b/core/conversion/converters/impl/softmax.cpp
@@ -26,12 +26,17 @@ static auto softmax_registrations TRTORCH_UNUSED = RegisterNodeConversionPattern
        }
 
        int64_t dim = args[1].IValue()->toInt();
+       LOG_DEBUG("Softmax original dim " << dim);
+       if (dim == -1) {
+         dim = shape.size() - 1;
+       }
+       LOG_DEBUG("Softmax converted dim " << dim);
        auto softmax = ctx->net->addSoftMax(*in);
 
        TRTORCH_CHECK(softmax, "Unable to create softmax layer from node: " << *n);
        LOG_DEBUG("Disregarding dtype argument");
 
-       if (shape.size() > 3) {
+       if (shape.size() > 1) {
          softmax->setAxes(1 << (dim));
        } else {
          // When there is no batch dimension

--- a/core/conversion/converters/impl/softmax.cpp
+++ b/core/conversion/converters/impl/softmax.cpp
@@ -27,8 +27,8 @@ static auto softmax_registrations TRTORCH_UNUSED = RegisterNodeConversionPattern
 
        int64_t dim = args[1].IValue()->toInt();
        LOG_DEBUG("Softmax original dim " << dim);
-       if (dim == -1) {
-         dim = shape.size() - 1;
+       if (dim < 0) {
+         dim = shape.size() + dim;
        }
        LOG_DEBUG("Softmax converted dim " << dim);
        auto softmax = ctx->net->addSoftMax(*in);

--- a/tests/core/conversion/converters/test_softmax.cpp
+++ b/tests/core/conversion/converters/test_softmax.cpp
@@ -77,11 +77,37 @@ TEST(Converters, ATenSoftmaxNDConvertsCorrectlyAbove3DIndex) {
   ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
 }
 
-TEST(Converters, ATenSoftmaxNDConvertsCorrectlyNegtiveIndex) {
+TEST(Converters, ATenSoftmaxNDConvertsCorrectlyNegtiveOneIndex) {
   const auto graph = R"IR(
       graph(%0 : Tensor):
         %1 : None = prim::Constant()
         %2 : int = prim::Constant[value=-1]()
+        %3 : Tensor = aten::softmax(%0, %2, %1)
+        return (%3))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto in = at::randint(0, 5, {1, 2, 2, 2, 2}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  auto trt = trt_results[0].reshape_as(jit_results[0]);
+
+  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}
+
+TEST(Converters, ATenSoftmaxNDConvertsCorrectlyNegtiveIndex) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %1 : None = prim::Constant()
+        %2 : int = prim::Constant[value=-2]()
         %3 : Tensor = aten::softmax(%0, %2, %1)
         return (%3))IR";
 

--- a/tests/core/conversion/converters/test_softmax.cpp
+++ b/tests/core/conversion/converters/test_softmax.cpp
@@ -76,3 +76,29 @@ TEST(Converters, ATenSoftmaxNDConvertsCorrectlyAbove3DIndex) {
 
   ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
 }
+
+TEST(Converters, ATenSoftmaxNDConvertsCorrectlyNegtiveIndex) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %1 : None = prim::Constant()
+        %2 : int = prim::Constant[value=-1]()
+        %3 : Tensor = aten::softmax(%0, %2, %1)
+        return (%3))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto in = at::randint(0, 5, {1, 2, 2, 2, 2}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  auto trt = trt_results[0].reshape_as(jit_results[0]);
+
+  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt, 2e-6));
+}


### PR DESCRIPTION
# Description

Lets softmax handle index -1

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes