### PR TITLE
aten::detach removal pass

### DIFF
--- a/core/lowering/lowering.cpp
+++ b/core/lowering/lowering.cpp
@@ -47,7 +47,7 @@ void LowerGraph(std::shared_ptr<torch::jit::Graph>& g) {
   passes::UnpackAddMM(g);
   // passes::UnpackBatchNorm(g);
   passes::UnpackLogSoftmax(g);
-  passes::RemoveTo(g);
+  passes::RemoveNOPs(g);
   torch::jit::EliminateDeadCode(g);
   LOG_GRAPH(*g);
 }

--- a/core/lowering/passes/BUILD
+++ b/core/lowering/passes/BUILD
@@ -21,7 +21,7 @@ cc_library(
         "remove_bn_dim_check.cpp",
         "remove_contiguous.cpp",
         "remove_dropout.cpp",
-        "remove_to.cpp",
+        "remove_nops.cpp",
         "unpack_addmm.cpp",
         "unpack_batch_norm.cpp",
         "unpack_log_softmax.cpp",

--- a/core/lowering/passes/passes.h
+++ b/core/lowering/passes/passes.h
@@ -15,7 +15,7 @@ void EliminateExceptionOrPassPattern(std::shared_ptr<torch::jit::Graph> graph);
 void RemoveBNDimCheck(std::shared_ptr<torch::jit::Graph> graph);
 void RemoveContiguous(std::shared_ptr<torch::jit::Graph>& graph);
 void RemoveDropout(std::shared_ptr<torch::jit::Graph>& graph);
-void RemoveTo(std::shared_ptr<torch::jit::Graph> graph);
+void RemoveNOPs(std::shared_ptr<torch::jit::Graph> graph);
 void UnpackAddMM(std::shared_ptr<torch::jit::Graph>& graph);
 void UnpackBatchNorm(std::shared_ptr<torch::jit::Graph>& graph);
 void UnpackLogSoftmax(std::shared_ptr<torch::jit::Graph>& graph);

--- a/core/lowering/passes/remove_nops.cpp
+++ b/core/lowering/passes/remove_nops.cpp
@@ -29,7 +29,6 @@ struct NOPRemoval {
   }
 
  private:
-
   void removeNode(Block* b, std::string op) {
     for (auto it = b->nodes().begin(); it != b->nodes().end(); it++) {
       auto n = *it;

--- a/tests/core/lowering/BUILD
+++ b/tests/core/lowering/BUILD
@@ -15,10 +15,15 @@ lowering_test(
   name = "test_remove_to",
 )
 
+lowering_test(
+  name = "test_remove_detach_pass",
+)
+
 test_suite(
     name = "lowering_tests",
     tests = [
         ":test_remove_contiguous_pass",
-        ":test_remove_to"
+        ":test_remove_to",
+        ":test_remove_detach_pass"
     ]
 )

--- a/tests/core/lowering/test_remove_contiguous_pass.cpp
+++ b/tests/core/lowering/test_remove_contiguous_pass.cpp
@@ -17,6 +17,7 @@ TEST(LoweringPasses, RemoveContiguousLowersCorrectly) {
       %3 = foo::bar(%input)
       return (%3))IR";
 
+  trtorch::core::util::logging::get_logger().set_reportable_log_level(trtorch::core::util::logging::LogLevel::kGRAPH);
   auto sg = std::make_shared<torch::jit::Graph>();
   torch::jit::parseIR(source_graph, &*sg);
   trtorch::core::lowering::passes::RemoveContiguous(sg);

--- a/tests/core/lowering/test_remove_detach_pass.cpp
+++ b/tests/core/lowering/test_remove_detach_pass.cpp
@@ -17,9 +17,10 @@ TEST(LoweringPasses, RemoveDetachCorrectly) {
       %3 = aten::sin(%input)
       return (%3))IR";
 
+  trtorch::core::util::logging::get_logger().set_reportable_log_level(trtorch::core::util::logging::LogLevel::kGRAPH);
   auto sg = std::make_shared<torch::jit::Graph>();
   torch::jit::parseIR(source_graph, &*sg);
-  trtorch::core::lowering::passes::RemoveTo(sg);
+  trtorch::core::lowering::passes::RemoveNOPs(sg);
 
   auto tg = std::make_shared<torch::jit::Graph>();
   torch::jit::parseIR(target_graph, &*tg);

--- a/tests/core/lowering/test_remove_detach_pass.cpp
+++ b/tests/core/lowering/test_remove_detach_pass.cpp
@@ -10,16 +10,16 @@ TEST(LoweringPasses, RemoveDetachCorrectly) {
   std::string source_graph = R"IR(
     graph(%input):
       %2 = aten::detach(%input)
-      %3 = foo::bar(%2)
+      %3 = aten::sin(%2)
       return (%3))IR";
   std::string target_graph = R"IR(
     graph(%input):
-      %3 = foo::bar(%input)
+      %3 = aten::sin(%input)
       return (%3))IR";
 
   auto sg = std::make_shared<torch::jit::Graph>();
   torch::jit::parseIR(source_graph, &*sg);
-  trtorch::core::lowering::passes::RemoveContiguous(sg);
+  trtorch::core::lowering::passes::RemoveTo(sg);
 
   auto tg = std::make_shared<torch::jit::Graph>();
   torch::jit::parseIR(target_graph, &*tg);

--- a/tests/core/lowering/test_remove_detach_pass.cpp
+++ b/tests/core/lowering/test_remove_detach_pass.cpp
@@ -1,0 +1,28 @@
+#include <string>
+#include "core/compiler.h"
+#include "core/lowering/passes/passes.h"
+#include "gtest/gtest.h"
+#include "tests/util/util.h"
+#include "torch/csrc/jit/ir/irparser.h"
+#include "torch/csrc/jit/ir/subgraph_matcher.h"
+
+TEST(LoweringPasses, RemoveDetachCorrectly) {
+  std::string source_graph = R"IR(
+    graph(%input):
+      %2 = aten::detach(%input)
+      %3 = foo::bar(%2)
+      return (%3))IR";
+  std::string target_graph = R"IR(
+    graph(%input):
+      %3 = foo::bar(%input)
+      return (%3))IR";
+
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, &*sg);
+  trtorch::core::lowering::passes::RemoveContiguous(sg);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, &*tg);
+
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}

--- a/tests/core/lowering/test_remove_to.cpp
+++ b/tests/core/lowering/test_remove_to.cpp
@@ -1,12 +1,13 @@
 #include <string>
 #include "core/compiler.h"
 #include "core/lowering/passes/passes.h"
+#include "core/util/prelude.h"
 #include "gtest/gtest.h"
 #include "tests/util/util.h"
 #include "torch/csrc/jit/ir/irparser.h"
 #include "torch/csrc/jit/ir/subgraph_matcher.h"
 
-TEST(LoweringPasses, RemoveContiguousLowersCorrectly) {
+TEST(LoweringPasses, RemoveToLowersCorrectly) {
   std::string source_graph = R"IR(
     graph(%x.1):
       %6 : None = prim::Constant()
@@ -14,15 +15,16 @@ TEST(LoweringPasses, RemoveContiguousLowersCorrectly) {
       %3 : int = prim::Constant[value=5]() # experiments/test.py:8:17
       %y.1 : Tensor = aten::to(%x.1, %3, %4, %4, %6)
       %11 : Tensor = aten::relu(%y.1)
-      return (%3))IR";
+      return (%11))IR";
   std::string target_graph = R"IR(
     graph(%x.1):
       %11 : Tensor = aten::relu(%x.1)
       return (%11))IR";
 
+  trtorch::core::util::logging::get_logger().set_reportable_log_level(trtorch::core::util::logging::LogLevel::kGRAPH);
   auto sg = std::make_shared<torch::jit::Graph>();
   torch::jit::parseIR(source_graph, &*sg);
-  trtorch::core::lowering::passes::RemoveContiguous(sg);
+  trtorch::core::lowering::passes::RemoveNOPs(sg);
 
   auto tg = std::make_shared<torch::jit::Graph>();
   torch::jit::parseIR(target_graph, &*tg);


### PR DESCRIPTION
# Description

Adds a lowering pass to remove Detach ops which have no meaning in TensorRT. 

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes