### PR TITLE
Fix the test for the renamed op aliasing pass

### DIFF
--- a/tests/core/lowering/test_operator_aliasing_pass.cpp
+++ b/tests/core/lowering/test_operator_aliasing_pass.cpp
@@ -18,7 +18,7 @@ TEST(LoweringPasses, LoweringTrueDivideCorrectly) {
 
   auto sg = std::make_shared<torch::jit::Graph>();
   torch::jit::parseIR(source_graph, &*sg);
-  trtorch::core::lowering::passes::ElementWisePass(sg);
+  trtorch::core::lowering::passes::AliasOperators(sg);
 
   auto tg = std::make_shared<torch::jit::Graph>();
   torch::jit::parseIR(target_graph, &*tg);


### PR DESCRIPTION
# Description

Fix the test for the renamed op aliasing pass

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes