### PR TITLE
Verify zeros evaluator works correctly and detect programs that will have an empty TensorRT engine

### DIFF
--- a/core/conversion/conversion.cpp
+++ b/core/conversion/conversion.cpp
@@ -436,7 +436,8 @@ std::set<std::string> GetUnsupportedOpsInBlock(const torch::jit::Block* b) {
 std::set<std::string> ConvertableOpsInBlock(const torch::jit::Block* b) {
   std::set<std::string> convertable_ops;
   for (const auto n : b->nodes()) {
-    if (n->kind() == torch::jit::prim::Loop || n->kind() == torch::jit::prim::If || converters::node_is_convertable(n)) {
+    if (n->kind() == torch::jit::prim::Loop || n->kind() == torch::jit::prim::If ||
+        converters::node_is_convertable(n)) {
       if (n->blocks().size() > 0) {
         for (const auto sub_b : n->blocks()) {
           auto sub_b_convertable_ops = ConvertableOpsInBlock(sub_b);
@@ -446,8 +447,7 @@ std::set<std::string> ConvertableOpsInBlock(const torch::jit::Block* b) {
       if (converters::node_is_convertable(n)) {
         auto schema = n->maybeSchema();
         TRTORCH_CHECK(
-            schema,
-            "Unable to get schema for Node " << util::node_info(n) << " (conversion.CheckForConvertableOps)");
+            schema, "Unable to get schema for Node " << util::node_info(n) << " (conversion.CheckForConvertableOps)");
         std::stringstream ss;
         ss << *schema;
         convertable_ops.insert(ss.str());
@@ -476,10 +476,12 @@ bool VerifyConverterSupportForBlock(const torch::jit::Block* b) {
 
   if (ConvertableOpsInBlock(b).size() == 0) {
     std::stringstream unsupported_msg;
-    unsupported_msg << "Method requested cannot be compiled by TRTorch.\nThere is no work to be done since the resulting compiled program will contain an engine that is empty."
-                    << std::endl;
-    unsupported_msg << "This may be because there are no operators that can be added to the TensorRT graph or all operators have a resolved compile time value."
-                    << std::endl;
+    unsupported_msg
+        << "Method requested cannot be compiled by TRTorch.\nThere is no work to be done since the resulting compiled program will contain an engine that is empty."
+        << std::endl;
+    unsupported_msg
+        << "This may be because there are no operators that can be added to the TensorRT graph or all operators have a resolved compile time value."
+        << std::endl;
     LOG_ERROR(unsupported_msg.str());
     return false;
   }

--- a/core/conversion/evaluators/aten.cpp
+++ b/core/conversion/evaluators/aten.cpp
@@ -119,11 +119,16 @@ auto aten_registrations TRTORCH_UNUSED =
                     // Device? device=None, bool? pin_memory=None) -> (Tensor)
                     [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
                       auto options = torch::TensorOptions()
-                                         .dtype(c10::ScalarType(args.at(n->output(1)).unwrapToInt()))
                                          .layout(torch::kStrided)
                                          .device(torch::kCUDA);
 
+                      if (!args.at(n->input(1)).isNone() && !args.at(n->input(1)).IValue()->isNone()) {
+                        options = options.dtype(c10::ScalarType(args.at(n->input(1)).unwrapToInt()));
+                      }
+
                       auto out_tensor = torch::zeros(args.at(n->input(0)).unwrapToIntList().vec(), options);
+                      std::cout << out_tensor << std::endl;
+                      std::cout << out_tensor.sizes() << std::endl;
                       return out_tensor;
                     }})
         .evaluator({c10::Symbol::fromQualString("aten::slice"),

--- a/core/conversion/evaluators/aten.cpp
+++ b/core/conversion/evaluators/aten.cpp
@@ -127,8 +127,6 @@ auto aten_registrations TRTORCH_UNUSED =
                       }
 
                       auto out_tensor = torch::zeros(args.at(n->input(0)).unwrapToIntList().vec(), options);
-                      std::cout << out_tensor << std::endl;
-                      std::cout << out_tensor.sizes() << std::endl;
                       return out_tensor;
                     }})
         .evaluator({c10::Symbol::fromQualString("aten::slice"),

--- a/core/conversion/evaluators/aten.cpp
+++ b/core/conversion/evaluators/aten.cpp
@@ -120,6 +120,7 @@ auto aten_registrations TRTORCH_UNUSED =
                     [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
                       auto options = torch::TensorOptions().layout(torch::kStrided).device(torch::kCUDA);
 
+                      // Input 1 here is the dtype
                       if (!args.at(n->input(1)).isNone() && !args.at(n->input(1)).IValue()->isNone()) {
                         options = options.dtype(c10::ScalarType(args.at(n->input(1)).unwrapToInt()));
                       }

--- a/core/conversion/evaluators/aten.cpp
+++ b/core/conversion/evaluators/aten.cpp
@@ -118,9 +118,7 @@ auto aten_registrations TRTORCH_UNUSED =
                     // aten::zeros(int[] size, *, int? dtype=None, int? layout=None,
                     // Device? device=None, bool? pin_memory=None) -> (Tensor)
                     [](const torch::jit::Node* n, kwargs& args) -> c10::optional<torch::jit::IValue> {
-                      auto options = torch::TensorOptions()
-                                         .layout(torch::kStrided)
-                                         .device(torch::kCUDA);
+                      auto options = torch::TensorOptions().layout(torch::kStrided).device(torch::kCUDA);
 
                       if (!args.at(n->input(1)).isNone() && !args.at(n->input(1)).IValue()->isNone()) {
                         options = options.dtype(c10::ScalarType(args.at(n->input(1)).unwrapToInt()));

--- a/tests/core/conversion/evaluators/test_aten_evaluators.cpp
+++ b/tests/core/conversion/evaluators/test_aten_evaluators.cpp
@@ -37,3 +37,22 @@ TEST(Evaluators, DivFloatEvaluatesCorrectly) {
 
   ASSERT_TRUE(jit_results[0] == trt_results[0]);
 }
+
+TEST(Evaluators, ZerosEvaluatesCorrectly) {
+  const auto graph = R"IR(
+      graph(%x.1 : Tensor):
+        %2 : None = prim::Constant() # :0:0
+        %3 : int[] = aten::size(%x.1) # <string>:7:9
+        %z.1 : Tensor = aten::zeros(%3, %2, %2, %2, %2) # experiments/test_zeros.py:8:12
+        return (%z.1))IR";
+
+  auto in = at::randint(1, 10, {1, 5, 5, 5}, {at::kCUDA});
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto jit_results = trtorch::tests::util::EvaluateGraphJIT(g, {in});
+  auto trt_results = trtorch::tests::util::EvaluateGraph(g->block(), {in});
+
+  ASSERT_TRUE(at::equal(jit_results[0].toTensor().to(at::kCUDA), trt_results[0].toTensor()));
+}

--- a/tests/core/conversion/evaluators/test_aten_evaluators.cpp
+++ b/tests/core/conversion/evaluators/test_aten_evaluators.cpp
@@ -56,3 +56,23 @@ TEST(Evaluators, ZerosEvaluatesCorrectly) {
 
   ASSERT_TRUE(at::equal(jit_results[0].toTensor().to(at::kCUDA), trt_results[0].toTensor()));
 }
+
+TEST(Evaluators, ZerosDataTypeEvaluatesCorrectly) {
+  const auto graph = R"IR(
+      graph(%x.1 : Tensor):
+        %2 : int = prim::Constant[value=5]() # :0:0 (Float16)
+        %3 : None = prim::Constant() # :0:0
+        %4 : int[] = aten::size(%x.1) # <string>:7:9
+        %z.1 : Tensor = aten::zeros(%4, %2, %3, %3, %3) # experiments/test_zeros.py:8:12
+        return (%z.1))IR";
+
+  auto in = at::randint(1, 10, {1, 5, 5, 5}, {at::kCUDA});
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto jit_results = trtorch::tests::util::EvaluateGraphJIT(g, {in});
+  auto trt_results = trtorch::tests::util::EvaluateGraph(g->block(), {in});
+
+  ASSERT_TRUE(at::equal(jit_results[0].toTensor().to(at::kCUDA), trt_results[0].toTensor()));
+}


### PR DESCRIPTION
# Description

This PR fixes the `aten::zeros` evaluator and adds a test to make sure it matches PyTorch execution. 
It also adds a check to see if a graph will result in a TensorRT engine that does nothing at runtime and errors out if so. 

Fixes #343 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes