### PR TITLE
fix(setup.py): Broaden the supported pytorch versions to handle jetson

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -204,7 +204,7 @@ setup(name='trtorch',
       long_description=long_description,
       ext_modules=ext_modules,
       install_requires=[
-          'torch==1.7.1',
+          'torch>=1.7.0,<1.8.0',
       ],
       setup_requires=[],
       cmdclass={


### PR DESCRIPTION
# Description

Jetson does not seem to have a 1.7.1 build so this PR expands the supported version of Pytorch in the setup.py

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes