### PR TITLE
more safe and easily readable use to get raw pointer of shared-pointer

### DIFF
--- a/tests/core/conversion/converters/test_activation.cpp
+++ b/tests/core/conversion/converters/test_activation.cpp
@@ -11,7 +11,7 @@ TEST(Converters, ATenReLUConvertsCorrectly) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(-5, 5, {5}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -31,7 +31,7 @@ TEST(Converters, ATenSigmoidConvertsCorrectly) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(-5, 5, {5}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -51,7 +51,7 @@ TEST(Converters, ATenTanhConvertsCorrectly) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(-5, 5, {5}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -75,7 +75,7 @@ TEST(Converters, ATenTanhConvertsCorrectly) {
 //         return (%3))IR";
 
 //     auto g = std::make_shared<torch::jit::Graph>();
-//     torch::jit::script::parseIR(graph, &*g);
+//     torch::jit::script::parseIR(graph, g.get());
 
 //     auto in = at::randint(-5, 5, {5}, {at::kCUDA});
 //     auto params = trtorch::core::conversion::get_named_params(g->inputs(),
@@ -98,7 +98,7 @@ TEST(Converters, ATenHardTanhCustomRangeConvertsCorrectly) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(-5, 5, {5}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -119,7 +119,7 @@ TEST(Converters, ATenPReLUConvertsCorrectly) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(-5, 5, {5}, {at::kCUDA});
   auto slope = at::randint(-5, 5, {1}, {at::kCUDA});
@@ -142,7 +142,7 @@ TEST(Converters, ATenPReLUMultiChannelConvertsCorrectly) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(-5, 5, {1, 10, 1, 1}, {at::kCUDA});
   auto slope = at::randint(-5, 5, {10}, {at::kCUDA});
@@ -165,7 +165,7 @@ TEST(Converters, ATenLeakyReluConvertsCorrectly) {
         return (%2))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(-5, 5, {5}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -187,7 +187,7 @@ TEST(Converters, ATenEluConvertsCorrectly) {
         return (%result.2))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(-5, 5, {1, 10, 1, 1}, {at::kCUDA});
 

--- a/tests/core/conversion/converters/test_batch_norm.cpp
+++ b/tests/core/conversion/converters/test_batch_norm.cpp
@@ -18,7 +18,7 @@ TEST(Converters, ATenBatchNormConvertsCorrectly) {
         return (%8))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 5, 5, 5}, {at::kCUDA});
   auto gamma = at::randint(1, 10, {5}, {at::kCUDA});

--- a/tests/core/conversion/converters/test_concat.cpp
+++ b/tests/core/conversion/converters/test_concat.cpp
@@ -14,7 +14,7 @@ TEST(Converters, ATenCatPureTensorConvertsCorrectly) {
         return (%4))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in1 = at::randint(1, 10, {5}, {at::kCUDA});
   auto in2 = at::randint(1, 10, {5}, {at::kCUDA});
@@ -38,7 +38,7 @@ TEST(Converters, ATenCatDiffTensorConvertsCorrectly) {
         return (%4))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in1 = at::randint(1, 10, {5}, {at::kCUDA});
   auto in2 = at::randint(1, 10, {5}, {at::kCUDA});

--- a/tests/core/conversion/converters/test_conv_deconv.cpp
+++ b/tests/core/conversion/converters/test_conv_deconv.cpp
@@ -12,7 +12,7 @@
 
 void conv_test_helper(std::string graph_ir) {
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph_ir, &*g);
+  torch::jit::parseIR(graph_ir, g.get());
 
   auto in = at::randint(1, 10, {1, 3, 10, 10}, {at::kCUDA});
   auto w = at::randint(1, 10, {8, 3, 5, 5}, {at::kCUDA});
@@ -54,7 +54,7 @@ TEST(Converters, ATenConvolutionConvertsCorrectly) {
         return (%12))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3, 10, 10}, {at::kCUDA});
   auto w = at::randint(1, 10, {8, 3, 5, 5}, {at::kCUDA});
@@ -96,7 +96,7 @@ TEST(Converters, ATenConvolutionNoBiasConvertsCorrectly) {
         return (%12))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 2, {1, 1, 3, 3}, {at::kCUDA});
   auto w = at::randint(1, 2, {4, 1, 2, 2}, {at::kCUDA});
@@ -135,7 +135,7 @@ TEST(Converters, ATenConvolutionWithStrideConvertsCorrectly) {
         return (%13))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3, 9, 9}, {at::kCUDA});
   auto w = at::randint(1, 10, {4, 3, 3, 3}, {at::kCUDA});
@@ -178,7 +178,7 @@ TEST(Converters, ATenConvolutionWithPaddingConvertsCorrectly) {
         return (%13))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3, 4, 4}, {at::kCUDA});
   auto w = at::randint(1, 10, {4, 3, 2, 2}, {at::kCUDA});
@@ -220,7 +220,7 @@ TEST(Converters, ATenConvolution3dConvertsCorrectly) {
         return (%out))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3, 5, 5, 5}, {at::kCUDA});
   auto w = at::randint(1, 10, {32, 3, 3, 3, 3}, {at::kCUDA});
@@ -262,7 +262,7 @@ TEST(Converters, ATenConvolution3dNoBiasConvertsCorrectly) {
         return (%out))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 2, {1, 3, 5, 5, 5}, {at::kCUDA});
   auto w = at::randint(1, 2, {32, 3, 3, 3, 3}, {at::kCUDA});
@@ -300,7 +300,7 @@ TEST(Converters, ATenConvolution3dWithPaddingConvertsCorrectly) {
         return (%out))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3, 5, 5, 5}, {at::kCUDA});
   auto w = at::randint(1, 10, {32, 3, 3, 3, 3}, {at::kCUDA});
@@ -342,7 +342,7 @@ TEST(Converters, ATenConvolution3dWithStrideDilationConvertsCorrectly) {
         return (%out))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3, 5, 5, 5}, {at::kCUDA});
   auto w = at::randint(1, 10, {32, 3, 3, 3, 3}, {at::kCUDA});
@@ -384,7 +384,7 @@ TEST(Converters, ATenConvTransposeConvertsCorrectly) {
         return (%12))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 3, {1, 8, 5, 5}, {at::kCUDA});
   auto w = at::randint(1, 3, {8, 3, 3, 3}, {at::kCUDA});
@@ -426,7 +426,7 @@ TEST(Converters, ATenConvTransposeNoBiasConvertsCorrectly) {
         return (%12))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 2, {1, 4, 3, 3}, {at::kCUDA});
   auto w = at::randint(1, 2, {4, 1, 2, 2}, {at::kCUDA});
@@ -465,7 +465,7 @@ TEST(Converters, ATenConvTransposeWithStrideConvertsCorrectly) {
         return (%13))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 4, 9, 9}, {at::kCUDA});
   auto w = at::randint(1, 10, {4, 3, 3, 3}, {at::kCUDA});
@@ -508,7 +508,7 @@ TEST(Converters, ATenConvTransposeWithPaddingConvertsCorrectly) {
         return (%13))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 4, 4, 4}, {at::kCUDA});
   auto w = at::randint(1, 10, {4, 3, 2, 2}, {at::kCUDA});
@@ -551,7 +551,7 @@ TEST(Converters, ATenConvolutionWithGroupConvertsCorrectly) {
         return (%13))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 4, 4, 4}, {at::kCUDA});
   auto w = at::randint(1, 10, {8, 1, 2, 2}, {at::kCUDA});
@@ -594,7 +594,7 @@ TEST(Converters, ATenConvTransposeWithGroupConvertsCorrectly) {
         return (%13))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 8, 5, 5}, {at::kCUDA});
   auto w = at::randint(1, 10, {8, 4, 3, 3}, {at::kCUDA});

--- a/tests/core/conversion/converters/test_element_wise.cpp
+++ b/tests/core/conversion/converters/test_element_wise.cpp
@@ -11,7 +11,7 @@ void pointwise_test_helper(
     std::vector<int64_t> shape1 = {5},
     std::vector<int64_t> shape2 = {5}) {
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph_ir, &*g);
+  torch::jit::parseIR(graph_ir, g.get());
 
   // singleInput case is enabled when elementwise operation is performed
   // with an input and a constant embedded in graph

--- a/tests/core/conversion/converters/test_expand.cpp
+++ b/tests/core/conversion/converters/test_expand.cpp
@@ -15,7 +15,7 @@ TEST(Converters, ATenExpandSameDimConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {3, 1}, {at::kCUDA});
 
@@ -42,7 +42,7 @@ TEST(Converters, ATenExpandSameDimConvertsCorrectlyWithDynamicInput) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {3, 1}, {at::kCUDA});
 
@@ -69,7 +69,7 @@ TEST(Converters, ATenExpandTileConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {3, 1}, {at::kCUDA});
 
@@ -96,7 +96,7 @@ TEST(Converters, ATenExpandTileConvertsCorrectlyWithDynamicInput) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {3, 1}, {at::kCUDA});
 
@@ -123,7 +123,7 @@ TEST(Converters, ATenExpandTileLastConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {3, 1}, {at::kCUDA});
 
@@ -150,7 +150,7 @@ TEST(Converters, ATenExpandTileLastConvertsCorrectlyWithDynamicInput) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {3, 1}, {at::kCUDA});
 
@@ -177,7 +177,7 @@ TEST(Converters, ATenExpandNegativeSizeConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {3, 1}, {at::kCUDA});
 
@@ -204,7 +204,7 @@ TEST(Converters, ATenExpandNegativeSizeConvertsCorrectlyWithDynamicInput) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {3, 1}, {at::kCUDA});
 
@@ -238,7 +238,7 @@ TEST(Converters, ATenExpandASConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {3, 1}, {at::kCUDA});
   auto target_in = at::randint(1, 10, {2, 3, 1}, {at::kCUDA});
@@ -270,7 +270,7 @@ TEST(Converters, ATenExpandAsConvertsCorrectlyWithDynamicInput) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {3, 1}, {at::kCUDA});
   auto target_in = at::randint(1, 10, {3, 4}, {at::kCUDA});
@@ -299,7 +299,7 @@ TEST(Converters, ATenRepeatConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3}, {at::kCUDA});
 
@@ -325,7 +325,7 @@ TEST(Converters, ATenRepeatConvertsCorrectlyWithDynamicInput) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3}, {at::kCUDA});
 
@@ -351,7 +351,7 @@ TEST(Converters, ATenRepeat3dConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {2, 3, 2}, {at::kCUDA});
 
@@ -377,7 +377,7 @@ TEST(Converters, ATenRepeat3dConvertsCorrectlyWithDynamicInput) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {2, 3, 2}, {at::kCUDA});
 
@@ -403,7 +403,7 @@ TEST(Converters, ATenRepeatExtraDimsConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3}, {at::kCUDA});
 
@@ -429,7 +429,7 @@ TEST(Converters, ATenRepeatExtraDimsConvertsCorrectlyWithDynamicInput) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3}, {at::kCUDA});
 

--- a/tests/core/conversion/converters/test_interpolate.cpp
+++ b/tests/core/conversion/converters/test_interpolate.cpp
@@ -9,7 +9,7 @@
     const auto graph = graph_src;                                                        \
                                                                                          \
     auto g = std::make_shared<torch::jit::Graph>();                                      \
-    torch::jit::parseIR(graph, &*g);                                                     \
+    torch::jit::parseIR(graph, g.get());                                                     \
                                                                                          \
     auto in = at::randint(1, 10, input_shape, {at::kCUDA});                              \
     auto jit_in = at::clone(in);                                                         \
@@ -28,7 +28,7 @@
     const auto graph = graph_src;                                                        \
                                                                                          \
     auto g = std::make_shared<torch::jit::Graph>();                                      \
-    torch::jit::parseIR(graph, &*g);                                                     \
+    torch::jit::parseIR(graph, g.get());                                                     \
                                                                                          \
     auto in = at::randint(1, 10, input_shape, {at::kCUDA});                              \
     auto jit_in = at::clone(in);                                                         \
@@ -48,7 +48,7 @@
     const auto graph = graph_src;                                                 \
                                                                                   \
     auto g = std::make_shared<torch::jit::Graph>();                               \
-    torch::jit::parseIR(graph, &*g);                                              \
+    torch::jit::parseIR(graph, g.get());                                              \
                                                                                   \
     auto in = at::randint(1, 10, input_shape, {at::kCUDA});                       \
     auto jit_in = at::clone(in);                                                  \

--- a/tests/core/conversion/converters/test_linear.cpp
+++ b/tests/core/conversion/converters/test_linear.cpp
@@ -13,7 +13,7 @@ TEST(Converters, ATenLinearNoBiasConvertsCorrectly) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // Input Tensor needs to be 4D for TensorRT linear
   auto in = at::randint(1, 10, {1, 2}, {at::kCUDA});
@@ -39,7 +39,7 @@ TEST(Converters, ATenLinearBiasConvertsCorrectly) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // WARN: TRT expects a 4D input eventually, but pytorch does not require a
   // channel dim

--- a/tests/core/conversion/converters/test_lstm_cell.cpp
+++ b/tests/core/conversion/converters/test_lstm_cell.cpp
@@ -18,7 +18,7 @@ TEST(Converters, ATenLSTMCellConvertsCorrectlyWithBiasCheckHidden) {
         return (%8))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto input = at::randn({50, 10}, {at::kCUDA});
   auto h0 = at::randn({50, 20}, {at::kCUDA});
@@ -69,7 +69,7 @@ TEST(Converters, ATenLSTMCellConvertsCorrectlyWithBiasCheckCell) {
         return (%9))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto input = at::randn({50, 10}, {at::kCUDA});
   auto h0 = at::randn({50, 20}, {at::kCUDA});
@@ -120,7 +120,7 @@ TEST(Converters, ATenLSTMCellConvertsCorrectlyWithoutBiasCheckHidden) {
         return (%8))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto input = at::randn({50, 10}, {at::kCUDA});
   auto h0 = at::randn({50, 20}, {at::kCUDA});
@@ -163,7 +163,7 @@ TEST(Converters, ATenLSTMCellConvertsCorrectlyWithoutBiasCheckCell) {
         return (%9))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto input = at::randn({50, 10}, {at::kCUDA});
   auto h0 = at::randn({50, 20}, {at::kCUDA});

--- a/tests/core/conversion/converters/test_matrix_multiply.cpp
+++ b/tests/core/conversion/converters/test_matrix_multiply.cpp
@@ -12,7 +12,7 @@ TEST(Converters, ATenMMConvertsCorrectly) {
         return (%2))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in1 = at::randint(0, 5, {2, 3}, {at::kCUDA});
   auto in2 = at::randint(0, 5, {3, 3}, {at::kCUDA});

--- a/tests/core/conversion/converters/test_pooling.cpp
+++ b/tests/core/conversion/converters/test_pooling.cpp
@@ -18,7 +18,7 @@ TEST(Converters, ATenMaxPool1DConvertsCorrectly) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(-5, 5, {1, 1, 10}, at::kCUDA);
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -45,7 +45,7 @@ TEST(Converters, ATenMaxPool2DConvertsCorrectly) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // PyTorch MaxPool needs a 3D input
   auto in = at::randint(-5, 5, {1, 10, 10}, at::kCUDA);
@@ -73,7 +73,7 @@ TEST(Converters, ATenMaxPool3DConvertsCorrectly) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // PyTorch MaxPool needs a 3D input
   auto in = at::randint(-5, 5, {1, 3, 10, 10, 10}, at::kCUDA);
@@ -103,7 +103,7 @@ TEST(Converters, ATenAvgPool1DConvertsCorrectly) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // PyTorch AvgPool needs a 3D input
   auto in = at::randint(-5, 5, {1, 1, 10}, at::kCUDA);
@@ -132,7 +132,7 @@ TEST(Converters, ATenAvgPool1DCeilConvertsCorrectly) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // PyTorch AvgPool needs a 3D input
   auto in = at::randint(-5, 5, {1, 1, 4}, at::kCUDA);
@@ -161,7 +161,7 @@ TEST(Converters, ATenAvgPool1DNoCountPadConvertsCorrectly) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // PyTorch AvgPool needs a 3D input
   auto in = at::randint(-5, 5, {1, 1, 4}, at::kCUDA);
@@ -191,7 +191,7 @@ TEST(Converters, ATenAvgPool2DConvertsCorrectly) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // PyTorch AvgPool needs a 3D input
   auto in = at::randint(-5, 5, {1, 4, 4}, at::kCUDA);
@@ -221,7 +221,7 @@ TEST(Converters, ATenAvgPool2DCeilConvertsCorrectly) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // PyTorch AvgPool needs a 3D input
   auto in = at::randint(-5, 5, {1, 4, 4}, at::kCUDA);
@@ -251,7 +251,7 @@ TEST(Converters, ATenAvgPool2DNoCountPadConvertsCorrectly) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // PyTorch AvgPool needs a 3D input
   auto in = at::randint(-5, 5, {1, 4, 4}, at::kCUDA);
@@ -281,7 +281,7 @@ TEST(Converters, ATenAvgPool3DConvertsCorrectly) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // PyTorch AvgPool needs a 3D input
   auto in = at::randint(-5, 5, {1, 3, 4, 4, 4}, at::kCUDA);
@@ -311,7 +311,7 @@ TEST(Converters, ATenAvgPool3DCeilConvertsCorrectly) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // PyTorch AvgPool needs a 3D input
   auto in = at::randint(-5, 5, {1, 3, 4, 4, 4}, at::kCUDA);
@@ -341,7 +341,7 @@ TEST(Converters, ATenAvgPool3DNoCountPadConvertsCorrectly) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // PyTorch AvgPool needs a 3D input
   auto in = at::randint(-5, 5, {1, 3, 4, 4, 4}, at::kCUDA);
@@ -365,7 +365,7 @@ TEST(Converters, ATenAdaptiveAvgPool2DConvertsCorrectly) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // PyTorch MaxPool needs a 3D input
   auto in = at::randint(-5, 5, {1, 12, 16}, at::kCUDA);
@@ -391,7 +391,7 @@ TEST(Converters, ATenAdaptiveAvgPool2DConvertsCorrectlyWithDynamicInput) {
         return (%10))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   // PyTorch MaxPool needs a 3D input
   auto in = at::randint(-5, 5, {10, 18, 36}, at::kCUDA);

--- a/tests/core/conversion/converters/test_reduce.cpp
+++ b/tests/core/conversion/converters/test_reduce.cpp
@@ -61,7 +61,7 @@ std::string gen_keepdim_graph(const std::string& op) {
 
 void test_body(const std::string& graph, at::Tensor& in) {
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
   auto jit_results = trtorch::tests::util::RunGraph(g, params, {in});

--- a/tests/core/conversion/converters/test_select.cpp
+++ b/tests/core/conversion/converters/test_select.cpp
@@ -14,7 +14,7 @@ TEST(Converters, ATenSelectIntConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
 
@@ -42,7 +42,7 @@ TEST(Converters, ATenSelectIntTwiceConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
 
@@ -69,7 +69,7 @@ TEST(Converters, ATenNarrowStartScalarConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {3, 2, 2, 4}, {at::kCUDA});
 
@@ -97,7 +97,7 @@ TEST(Converters, ATenEmbeddingConvertsCorrectly) {
   auto g = std::make_shared<torch::jit::Graph>();
 
   // Run Pytorch
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
   auto options_pyt = torch::TensorOptions().device(torch::kCUDA, 0).dtype(torch::kLong);
   auto jit_in = at::tensor({0, 1, 2}, options_pyt);
   auto embWeight = at::randn({10, 3}, {at::kCUDA});
@@ -130,7 +130,7 @@ TEST(Converters, ATenSliceConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3, 5, 5}, {at::kCUDA});
 
@@ -158,7 +158,7 @@ TEST(Converters, ATenSliceNegStartIndexConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {6, 3}, {at::kCUDA});
 
@@ -191,7 +191,7 @@ TEST(Converters, ATenSliceNegEndIndexConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {6, 5, 3, 3}, {at::kCUDA});
 
@@ -217,7 +217,7 @@ TEST(Converters, ATenSplitSizesInScriptingConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3, 4, 4}, {at::kCUDA});
 
@@ -245,7 +245,7 @@ TEST(Converters, ATenSplitSizesinTracingConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3, 4, 4}, {at::kCUDA});
 
@@ -272,7 +272,7 @@ TEST(Converters, ATenSplitFixedConvertsCorrectly) {
 
   auto g = std::make_shared<torch::jit::Graph>();
 
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {1, 3, 4, 4}, {at::kCUDA});
 

--- a/tests/core/conversion/converters/test_shuffle.cpp
+++ b/tests/core/conversion/converters/test_shuffle.cpp
@@ -14,7 +14,7 @@ TEST(Converters, ATenFlattenConvertsCorrectly) {
       return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {2, 3}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -38,7 +38,7 @@ TEST(Converters, ATenFlattenOtherDimsConvertsCorrectly) {
       return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {2, 3, 3}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -62,7 +62,7 @@ TEST(Converters, ATenReshapeConvertsCorrectly) {
       return (%4))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {2, 3}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -86,7 +86,7 @@ TEST(Converters, ATenViewConvertsCorrectly) {
       return (%4))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {2, 3}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -108,7 +108,7 @@ TEST(Converters, ATenPermuteConvertsCorrectly) {
       return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {2, 3, 2, 3}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -133,7 +133,7 @@ TEST(Converters, ATenPermute3DConvertsCorrectly) {
       return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {2, 2, 3}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -155,7 +155,7 @@ TEST(Converters, ATenPermute5DConvertsCorrectly) {
       return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {2, 2, 1, 2, 3}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -178,7 +178,7 @@ TEST(Converters, ATenFlattenConvertsCorrectlyWithDynamicInput) {
       return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {2, 3}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -201,7 +201,7 @@ TEST(Converters, ATenFlattenConvertsCorrectlyWithDynamicBatch) {
       return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {2, 3}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});

--- a/tests/core/conversion/converters/test_softmax.cpp
+++ b/tests/core/conversion/converters/test_softmax.cpp
@@ -13,7 +13,7 @@ TEST(Converters, ATenSoftmax1DConvertsCorrectly) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {5}, {at::kCUDA});
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
@@ -36,7 +36,7 @@ TEST(Converters, ATenSoftmaxNDConvertsCorrectlySub3DIndex) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {1, 2, 2, 2, 2}, {at::kCUDA});
 
@@ -60,7 +60,7 @@ TEST(Converters, ATenSoftmaxNDConvertsCorrectlyAbove3DIndex) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {1, 2, 2, 2, 2}, {at::kCUDA});
 
@@ -86,7 +86,7 @@ TEST(Converters, ATenSoftmaxNDConvertsCorrectlyNegtiveOneIndex) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {1, 2, 2, 2, 2}, {at::kCUDA});
 
@@ -112,7 +112,7 @@ TEST(Converters, ATenSoftmaxNDConvertsCorrectlyNegtiveIndex) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(0, 5, {1, 2, 2, 2, 2}, {at::kCUDA});
 

--- a/tests/core/conversion/converters/test_squeeze.cpp
+++ b/tests/core/conversion/converters/test_squeeze.cpp
@@ -12,7 +12,7 @@ TEST(Converters, ATenSqueezeConvertsCorrectly) {
         return (%2))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {2, 1, 3, 3}, {at::kCUDA});
 

--- a/tests/core/conversion/converters/test_stack.cpp
+++ b/tests/core/conversion/converters/test_stack.cpp
@@ -14,7 +14,7 @@ TEST(Converters, ATenStackPureTensorConvertsCorrectly) {
         return (%4))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in1 = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
   auto in2 = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
@@ -38,7 +38,7 @@ TEST(Converters, ATenStackDiffTensorConvertsCorrectly) {
         return (%4))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in1 = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});
   auto in2 = at::randint(1, 10, {4, 4, 4}, {at::kCUDA});

--- a/tests/core/conversion/converters/test_topk.cpp
+++ b/tests/core/conversion/converters/test_topk.cpp
@@ -15,7 +15,7 @@ TEST(Converters, ATenTopKConvertsCorrectly) {
         return (%5, %6))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::rand({10, 10, 100}, {at::kCUDA});
 

--- a/tests/core/conversion/converters/test_unary.cpp
+++ b/tests/core/conversion/converters/test_unary.cpp
@@ -19,7 +19,7 @@ std::string gen_test_graph(const std::string& unary) {
     const auto graph = gen_test_graph(#unary);                                            \
                                                                                           \
     auto g = std::make_shared<torch::jit::Graph>();                                       \
-    torch::jit::parseIR(graph, &*g);                                                      \
+    torch::jit::parseIR(graph, g.get());                                                      \
                                                                                           \
     float offset = 0;                                                                     \
     if (strcmp(#name, "Acosh") == 0)                                                      \

--- a/tests/core/conversion/converters/test_unsqueeze.cpp
+++ b/tests/core/conversion/converters/test_unsqueeze.cpp
@@ -12,7 +12,7 @@ TEST(Converters, ATenUnsqueezeConvertsCorrectly) {
         return (%2))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto in = at::randint(1, 10, {2, 3, 3}, {at::kCUDA});
 

--- a/tests/core/conversion/evaluators/test_aten_evaluators.cpp
+++ b/tests/core/conversion/evaluators/test_aten_evaluators.cpp
@@ -13,7 +13,7 @@ TEST(Evaluators, DivIntEvaluatesCorrectly) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto jit_results = trtorch::tests::util::EvaluateGraphJIT(g, {});
   auto trt_results = trtorch::tests::util::EvaluateGraph(g->block(), {});
@@ -30,7 +30,7 @@ TEST(Evaluators, DivFloatEvaluatesCorrectly) {
         return (%3))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto jit_results = trtorch::tests::util::EvaluateGraphJIT(g, {});
   auto trt_results = trtorch::tests::util::EvaluateGraph(g->block(), {});
@@ -49,7 +49,7 @@ TEST(Evaluators, ZerosEvaluatesCorrectly) {
   auto in = at::randint(1, 10, {1, 5, 5, 5}, {at::kCUDA});
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto jit_results = trtorch::tests::util::EvaluateGraphJIT(g, {in});
   auto trt_results = trtorch::tests::util::EvaluateGraph(g->block(), {in});
@@ -69,7 +69,7 @@ TEST(Evaluators, ZerosDataTypeEvaluatesCorrectly) {
   auto in = at::randint(1, 10, {1, 5, 5, 5}, {at::kCUDA});
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto jit_results = trtorch::tests::util::EvaluateGraphJIT(g, {in});
   auto trt_results = trtorch::tests::util::EvaluateGraph(g->block(), {in});

--- a/tests/core/conversion/evaluators/test_prim_evaluators.cpp
+++ b/tests/core/conversion/evaluators/test_prim_evaluators.cpp
@@ -11,7 +11,7 @@ TEST(Evaluators, PrimConstantEvaluatesCorrectly) {
         return (%0))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto jit_results = trtorch::tests::util::EvaluateGraphJIT(g, {});
   auto trt_results = trtorch::tests::util::EvaluateGraph(g->block(), {});
@@ -29,7 +29,7 @@ TEST(Evaluators, PrimListUnpackEvaluatesCorrectly) {
         return (%lu.1, %lu.2))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto jit_results = trtorch::tests::util::EvaluateGraphJIT(g, {});
   auto trt_results = trtorch::tests::util::EvaluateGraph(g->block(), {});
@@ -46,7 +46,7 @@ TEST(Evaluators, NumToTensorEvaluatesCorrectly) {
         return (%lu.1))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(graph, &*g);
+  torch::jit::parseIR(graph, g.get());
 
   auto jit_results = trtorch::tests::util::EvaluateGraphJIT(g, {});
   auto trt_results = trtorch::tests::util::EvaluateGraph(g->block(), {});

--- a/tests/core/lowering/test_operator_aliasing_pass.cpp
+++ b/tests/core/lowering/test_operator_aliasing_pass.cpp
@@ -17,11 +17,11 @@ TEST(LoweringPasses, LoweringTrueDivideCorrectly) {
       return (%2))IR";
 
   auto sg = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(source_graph, &*sg);
+  torch::jit::parseIR(source_graph, sg.get());
   trtorch::core::lowering::passes::AliasOperators(sg);
 
   auto tg = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(target_graph, &*tg);
+  torch::jit::parseIR(target_graph, tg.get());
 
   ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
 }

--- a/tests/core/lowering/test_remove_contiguous_pass.cpp
+++ b/tests/core/lowering/test_remove_contiguous_pass.cpp
@@ -19,11 +19,11 @@ TEST(LoweringPasses, RemoveContiguousLowersCorrectly) {
 
   trtorch::core::util::logging::get_logger().set_reportable_log_level(trtorch::core::util::logging::LogLevel::kGRAPH);
   auto sg = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(source_graph, &*sg);
+  torch::jit::parseIR(source_graph, sg.get());
   trtorch::core::lowering::passes::RemoveContiguous(sg);
 
   auto tg = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(target_graph, &*tg);
+  torch::jit::parseIR(target_graph, tg.get());
 
   ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
 }

--- a/tests/core/lowering/test_remove_detach_pass.cpp
+++ b/tests/core/lowering/test_remove_detach_pass.cpp
@@ -19,11 +19,11 @@ TEST(LoweringPasses, RemoveDetachCorrectly) {
 
   trtorch::core::util::logging::get_logger().set_reportable_log_level(trtorch::core::util::logging::LogLevel::kGRAPH);
   auto sg = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(source_graph, &*sg);
+  torch::jit::parseIR(source_graph, sg.get());
   trtorch::core::lowering::passes::RemoveNOPs(sg);
 
   auto tg = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(target_graph, &*tg);
+  torch::jit::parseIR(target_graph, tg.get());
 
   ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
 }

--- a/tests/core/lowering/test_remove_to.cpp
+++ b/tests/core/lowering/test_remove_to.cpp
@@ -23,11 +23,11 @@ TEST(LoweringPasses, RemoveToLowersCorrectly) {
 
   trtorch::core::util::logging::get_logger().set_reportable_log_level(trtorch::core::util::logging::LogLevel::kGRAPH);
   auto sg = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(source_graph, &*sg);
+  torch::jit::parseIR(source_graph, sg.get());
   trtorch::core::lowering::passes::RemoveNOPs(sg);
 
   auto tg = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(target_graph, &*tg);
+  torch::jit::parseIR(target_graph, tg.get());
 
   ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
 }

--- a/tests/core/lowering/test_silu_to_sigmoid_multiplication.cpp
+++ b/tests/core/lowering/test_silu_to_sigmoid_multiplication.cpp
@@ -19,11 +19,11 @@ TEST(LoweringPasses, RemoveSiluLowersCorrectly) {
 
   trtorch::core::util::logging::get_logger().set_reportable_log_level(trtorch::core::util::logging::LogLevel::kGRAPH);
   auto sg = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(source_graph, &*sg);
+  torch::jit::parseIR(source_graph, sg.get());
   trtorch::core::lowering::passes::SiluToSigmoidMultipication(sg);
 
   auto tg = std::make_shared<torch::jit::Graph>();
-  torch::jit::parseIR(target_graph, &*tg);
+  torch::jit::parseIR(target_graph, tg.get());
 
   ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
 }


### PR DESCRIPTION

# Description

## before
```cpp
  auto g = std::make_shared<torch::jit::Graph>();
  torch::jit::parseIR(graph, &*g);
```

## after
```cpp
  auto g = std::make_shared<torch::jit::Graph>();
  torch::jit::parseIR(graph, g.get());
```

Refer to [this thread](https://stackoverflow.com/questions/505143/getting-a-normal-ptr-from-shared-ptr) uploaded on Stack Overflow.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes