### PR TITLE
fix(//core/conversion/conversionctx): Fix memory leak in conversionctx

### DIFF
--- a/core/conversion/conversionctx/ConversionCtx.cpp
+++ b/core/conversion/conversionctx/ConversionCtx.cpp
@@ -148,7 +148,9 @@ std::string ConversionCtx::SerializeEngine() {
   auto engine = builder->buildEngineWithConfig(*net, *cfg);
   auto serialized_engine = engine->serialize();
   engine->destroy();
-  return std::string((const char*)serialized_engine->data(), serialized_engine->size());
+  auto engine_str = std::string((const char*)serialized_engine->data(), serialized_engine->size());
+  serialized_engine->destroy();
+  return engine_str;
 }
 
 bool ConversionCtx::CheckLayerAddition(const torch::jit::Node* n) {

--- a/py/trtorch/_compiler.py
+++ b/py/trtorch/_compiler.py
@@ -157,5 +157,6 @@ def get_build_info() -> str:
     build_info = "TRTorch Version: " + str(__version__) + '\n' + build_info
     return build_info
 
+
 def set_device(gpu_id):
     trtorch._C.set_device(gpu_id)

--- a/tests/py/test_multi_gpu.py
+++ b/tests/py/test_multi_gpu.py
@@ -5,7 +5,9 @@ import torchvision.models as models
 
 from model_test_case import ModelTestCase
 
+
 class TestMultiGpuSwitching(ModelTestCase):
+
     def setUp(self):
         if torch.cuda.device_count() < 2:
             self.fail("Test is not relevant for this platform since number of available CUDA devices is less than 2")
@@ -55,11 +57,13 @@ class TestMultiGpuSwitching(ModelTestCase):
         trtorch.set_device(0)
         self.assertTrue(same < 2e-3)
 
+
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(TestMultiGpuSwitching.parametrize(TestMultiGpuSwitching, model=models.resnet18(pretrained=True)))
 
     return suite
+
 
 suite = test_suite()
 


### PR DESCRIPTION
# Description

Fixes a memory leak where the `IHostMemory` container for the produced serialized engine after conversion is not destructed properly. 

h/t: @SakodaShintaro

Fixes #375 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes