### PR TITLE
fix(//core/conversion/converters/Weights): Fix buffer allocation for weights data 

### DIFF
--- a/core/conversion/converters/Weights.cpp
+++ b/core/conversion/converters/Weights.cpp
@@ -81,7 +81,7 @@ Weights::Weights(ConversionCtx* ctx, at::Tensor t) {
   // Store the data in the conversion context so it remains until building is
   // complete
 
-  void* buf;
+  void* buf = nullptr;
 
   if (dtype_optional.value() == nvinfer1::DataType::kFLOAT) {
     buf = malloc(t_cpu.numel() * sizeof(float));


### PR DESCRIPTION
# Description

The memcpy for weights tensors over copies when the Tensor is not a FP32 tensor. This seems to be the root cause of segfaults observed in #326 as well as failing DLA tests on aarch64 when users try to compile a model that is already in FP16. 

Fixes #326 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes