### PR TITLE
Fix bug in squeeze

### DIFF
--- a/core/conversion/converters/impl/squeeze.cpp
+++ b/core/conversion/converters/impl/squeeze.cpp
@@ -25,6 +25,15 @@ auto squeeze_registrations TRTORCH_UNUSED = RegisterNodeConversionPatterns().pat
          dim = selfDim.size() + dim;
        }
 
+       if (selfDim[dim] != 1) {
+         auto identity = ctx->net->addIdentity(*self);
+         auto out = ctx->AssociateValueAndTensor(n->outputs()[0], identity->getOutput(0));
+
+         LOG_DEBUG("Output tensor shape: " << out->getDimensions());
+
+         return true;
+       }
+
        auto shuffle_layer = ctx->net->addShuffle(*self);
        TRTORCH_CHECK(shuffle_layer, "Unable to create shuffle layer from node: " << *n);
        shuffle_layer->setReshapeDimensions(util::squeezeDims(self->getDimensions(), dim));

--- a/core/conversion/converters/impl/squeeze.cpp
+++ b/core/conversion/converters/impl/squeeze.cpp
@@ -26,8 +26,7 @@ auto squeeze_registrations TRTORCH_UNUSED = RegisterNodeConversionPatterns().pat
        }
 
        if (selfDim[dim] != 1) {
-         auto identity = ctx->net->addIdentity(*self);
-         auto out = ctx->AssociateValueAndTensor(n->outputs()[0], identity->getOutput(0));
+         auto out = ctx->AssociateValueAndTensor(n->outputs()[0], self);
 
          LOG_DEBUG("Output tensor shape: " << out->getDimensions());
 

--- a/tests/core/conversion/converters/test_squeeze.cpp
+++ b/tests/core/conversion/converters/test_squeeze.cpp
@@ -27,21 +27,30 @@ TEST(Converters, ATenSqueezeConvertsCorrectly) {
 
 TEST(Converters, ATenSqueezeDontNeedSqueezeConvertsCorrectly) {
   const auto graph = R"IR(
-      graph(%0 : Tensor):
-        %1 : int = prim::Constant[value=1]()
-        %2 : Tensor = aten::squeeze(%0, %1)
-        return (%2))IR";
+      graph(%0 : Tensor, %1 : Tensor):
+        %2 : int = prim::Constant[value=1]()
+        %2.1 : Tensor = aten::add(%0, %1, %2)
+        %3 : Tensor = aten::squeeze(%2.1, %2)
+        %4 : Tensor = aten::add(%3, %1, %2)
+        return (%4))IR";
 
   auto g = std::make_shared<torch::jit::Graph>();
   torch::jit::parseIR(graph, &*g);
 
   auto in = at::randint(1, 10, {2, 3, 3}, {at::kCUDA});
+  auto in_add = at::randint(1, 10, {2, 3, 3}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto jit_in_add = at::clone(in_add);
 
   auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto jit_results = trtorch::tests::util::RunGraph(g, params, {in});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in, jit_in_add});
+
+  auto trt_in = at::clone(jit_in);
+  auto trt_in_add = at::clone(jit_in_add);
 
   params = trtorch::core::conversion::get_named_params(g->inputs(), {});
-  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {in});
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in, trt_in_add});
 
   ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
 }

--- a/tests/core/conversion/converters/test_squeeze.cpp
+++ b/tests/core/conversion/converters/test_squeeze.cpp
@@ -24,3 +24,24 @@ TEST(Converters, ATenSqueezeConvertsCorrectly) {
 
   ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
 }
+
+TEST(Converters, ATenSqueezeDontNeedSqueezeConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %1 : int = prim::Constant[value=1]()
+        %2 : Tensor = aten::squeeze(%0, %1)
+        return (%2))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto in = at::randint(1, 10, {2, 3, 3}, {at::kCUDA});
+
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {in});
+
+  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {in});
+
+  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}


### PR DESCRIPTION
…a judgment condition to handle this situation

Signed-off-by: Ruoqian Guo <ruoqiang@nvidia.com>

# Description

Some tensor like at::randint(1,10,{2,3,3}) dont need to squeeze and add a judgment condition to handle this situation. 

Fixes #392 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes