### PR TITLE
fix a bug when unsqueeze(self, dim)'s dim is negative, the result of …

### DIFF
--- a/core/conversion/converters/impl/unsqueeze.cpp
+++ b/core/conversion/converters/impl/unsqueeze.cpp
@@ -22,10 +22,10 @@ auto unsqueeze_registrations TRTORCH_UNUSED = RegisterNodeConversionPatterns().p
 
        auto selfDim = util::toVec(self->getDimensions());
        int64_t nbDims = selfDim.size();
-       TRTORCH_ASSERT(
+       TRTORCH_CHECK(
            dim <= nbDims && dim >= -(nbDims + 1),
-           "imension out of range (expected to be in range of [" << -(nbDims + 1) << ", " << nbDims << "], but got "
-                                                                 << dim << ")");
+           "Dimension out of range (expected to be in range of [" << -(nbDims + 1) << ", " << nbDims << "], but got "
+                                                                  << dim << ")");
        if (dim < 0) {
          dim = nbDims + 1 + dim;
        }

--- a/core/conversion/converters/impl/unsqueeze.cpp
+++ b/core/conversion/converters/impl/unsqueeze.cpp
@@ -21,8 +21,13 @@ auto unsqueeze_registrations TRTORCH_UNUSED = RegisterNodeConversionPatterns().p
        auto dim = args[1].unwrapToInt();
 
        auto selfDim = util::toVec(self->getDimensions());
+       int64_t nbDims = selfDim.size();
+       TRTORCH_ASSERT(
+           dim <= nbDims && dim >= -(nbDims + 1),
+           "imension out of range (expected to be in range of [" << -(nbDims + 1) << ", " << nbDims << "], but got "
+                                                                 << dim << ")");
        if (dim < 0) {
-         dim = selfDim.size() + dim;
+         dim = nbDims + 1 + dim;
        }
 
        auto shuffle_layer = ctx->net->addShuffle(*self);

--- a/tests/core/conversion/converters/test_unsqueeze.cpp
+++ b/tests/core/conversion/converters/test_unsqueeze.cpp
@@ -24,3 +24,24 @@ TEST(Converters, ATenUnsqueezeConvertsCorrectly) {
 
   ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
 }
+
+TEST(Converters, ATenUnsqueezeNegativeDimConvertsCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %1 : int = prim::Constant[value=-4]()
+        %2 : Tensor = aten::unsqueeze(%0, %1)
+        return (%2))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto in = at::randint(1, 10, {2, 3, 3}, {at::kCUDA});
+
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {in});
+
+  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {in});
+
+  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}


### PR DESCRIPTION
…it is wrong

Signed-off-by: Ruoqian Guo <ruoqiang@nvidia.com>

# Description

Fix a bug when unsqueeze(self, dim)'s dim is negative, the result of it is wrong.

Fixes #394 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes