### PR TITLE
fix bugs in split converter

### DIFF
--- a/core/conversion/converters/impl/select.cpp
+++ b/core/conversion/converters/impl/select.cpp
@@ -18,7 +18,7 @@ bool add_split(ConversionCtx* ctx, const torch::jit::Node* n, args& args, bool s
   auto in = args[0].ITensor();
   auto axis = args[2].unwrapToInt();
   auto inDimSize = in->getDimensions().d[axis];
-  auto numOutputs = 1;
+  auto numOutputs = 1, numRemainder = 0;
   std::vector<int64_t> sizes;
 
   if (split_list) {
@@ -27,10 +27,13 @@ bool add_split(ConversionCtx* ctx, const torch::jit::Node* n, args& args, bool s
   } else {
     auto split_size = args[1].unwrapToInt();
     numOutputs = inDimSize / split_size;
-    if (numOutputs == 1) {
+    numRemainder = inDimSize % split_size;
+    for (int i = 0; i < numOutputs; i++) {
       sizes.push_back(split_size);
-    } else {
-      sizes = std::vector<int64_t>(numOutputs, 1);
+    }
+    if (numRemainder) {
+      numOutputs += 1;
+      sizes.push_back(numRemainder);
     }
   }
 

--- a/core/conversion/converters/impl/select.cpp
+++ b/core/conversion/converters/impl/select.cpp
@@ -28,7 +28,7 @@ bool add_split(ConversionCtx* ctx, const torch::jit::Node* n, args& args, bool s
     auto split_size = args[1].unwrapToInt();
     numOutputs = inDimSize / split_size;
     numRemainder = inDimSize % split_size;
-    for (int i = 0; i < numOutputs; i++) {
+    for (int64_t i = 0; i < numOutputs; i++) {
       sizes.push_back(split_size);
     }
     if (numRemainder) {
@@ -45,7 +45,7 @@ bool add_split(ConversionCtx* ctx, const torch::jit::Node* n, args& args, bool s
   list.reserve(numOutputs);
 
   int start_idx = 0;
-  for (int i = 0; i < numOutputs; i++) {
+  for (int64_t i = 0; i < numOutputs; i++) {
     at::Tensor indices = torch::arange(start_idx, start_idx + sizes[i], 1).to(torch::kI32);
     auto indicesTensor = tensor_to_const(ctx, indices);
 

--- a/core/conversion/var/BUILD
+++ b/core/conversion/var/BUILD
@@ -19,7 +19,8 @@ cc_library(
     deps = [
         "@tensorrt//:nvinfer",
         "//core/util:prelude",
-        "//core/conversion/converters:weights"
+        "//core/conversion/converters:weights",
+        "//core/conversion/tensorcontainer:tensorcontainer"
     ] + select({
         ":use_pre_cxx11_abi":  ["@libtorch_pre_cxx11_abi//:libtorch"],
         "//conditions:default":  ["@libtorch//:libtorch"],

--- a/core/conversion/var/Var.cpp
+++ b/core/conversion/var/Var.cpp
@@ -94,17 +94,10 @@ nvinfer1::ITensor* Var::ITensorOrFreeze(ConversionCtx* ctx) {
       "Requested either IValue containing a Tensor, or ITensor, however Var type is " << type_name());
 
   nvinfer1::ITensor* out;
-  auto weights = converters::Weights();
+
   if (isIValue()) {
     if (ptr_.ivalue->isTensor()) {
-      auto tensor = ptr_.ivalue->toTensor();
-      if (tensor.scalar_type() == at::kLong) {
-        weights = converters::Weights(ctx, tensor.toType(at::kInt));
-      } else if (tensor.scalar_type() == at::kDouble) {
-        weights = converters::Weights(ctx, tensor.toType(at::kFloat));
-      } else {
-        weights = converters::Weights(ctx, tensor);
-      }
+      auto weights = converters::Weights(ctx, ptr_.ivalue->toTensor());
 
       auto const_layer = ctx->net->addConstant(weights.shape, weights.data);
       TRTORCH_CHECK(const_layer, "Unable to freeze tensor into constant layer");

--- a/core/conversion/var/Var.h
+++ b/core/conversion/var/Var.h
@@ -5,6 +5,7 @@
 
 #include "core/conversion/conversionctx/ConversionCtx.h"
 #include "core/conversion/converters/Weights.h"
+#include "core/conversion/tensorcontainer/TensorContainer.h"
 #include "core/util/prelude.h"
 #include "torch/csrc/jit/ir/ir.h"
 

--- a/tests/core/conversion/converters/test_select.cpp
+++ b/tests/core/conversion/converters/test_select.cpp
@@ -288,3 +288,60 @@ TEST(Converters, ATenSplitFixedConvertsCorrectly) {
     ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[i], trt, 2e-6));
   }
 }
+
+TEST(Converters, ATenSplitFixedHasRemainderConvertsCorrectly) {
+  const auto graph = R"IR(
+    graph(%argument_1.1 : Tensor):
+          %2 : int = prim::Constant[value=2]()
+          %2.1 : int = prim::Constant[value=1]()
+          %3 : Tensor[] = aten::split(%argument_1.1, %2, %2.1)
+          %4 : Tensor, %5 : Tensor, %6 : Tensor = prim::ListUnpack(%3)
+          return (%4, %5, %6))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, &*g);
+
+  auto in = at::randint(1, 10, {1, 5, 4, 4}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  for (size_t i = 0; i < jit_results.size(); i++) {
+    auto trt = trt_results[i].reshape(jit_results[i].sizes());
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[i], trt, 2e-6));
+  }
+}
+
+TEST(Converters, ATenSplitAndAddConvertsCorrectly) {
+  const auto graph = R"IR(
+    graph(%argument_1.1 : Tensor):
+          %2 : int = prim::Constant[value=2]()
+          %2.1 : int = prim::Constant[value=1]()
+          %3 : Tensor[] = aten::split(%argument_1.1, %2, %2.1)
+          %4 : Tensor, %5 : Tensor = prim::ListUnpack(%3)
+          %6 : Tensor = aten::add(%4, %5, %2.1)
+          return (%6))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+
+  torch::jit::parseIR(graph, &*g);
+
+  auto in = at::randint(1, 10, {1, 4, 4, 4}, {at::kCUDA});
+
+  auto jit_in = at::clone(in);
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
+
+  auto trt_in = at::clone(in);
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
+
+  for (size_t i = 0; i < jit_results.size(); i++) {
+    auto trt = trt_results[i].reshape(jit_results[i].sizes());
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[i], trt, 2e-6));
+  }
+}


### PR DESCRIPTION
Signed-off-by: Ruoqian Guo <ruoqiang@nvidia.com>

# Description

Fix Split Converter bugs.  

1. Fix bug in ```core/conversion/converters/select.cpp: add_split``` function. 
2. Modified the `Var::ITensorOrFreeze` function in `core/conversion/var/Var.cpp`.

In addition, i use the linters to ensure that my code matches the style guidelines. The linters changed the entire file(core/conversion/converters/impl/select.cpp) . I only modified the `add_split ` part in select.cpp.

Fixes #401 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes