### PR TITLE
fix bugs in embedding converter

### DIFF
--- a/core/conversion/converters/impl/select.cpp
+++ b/core/conversion/converters/impl/select.cpp
@@ -174,9 +174,11 @@ auto select_registrations TRTORCH_UNUSED =
             {"aten::embedding(Tensor weight, Tensor indices, int padding_idx=-1, bool scale_grad_by_freq=False, bool sparse=False) -> (Tensor)",
              [](ConversionCtx* ctx, const torch::jit::Node* n, args& args) -> bool {
                auto embeddingTensor = args[0].ITensorOrFreeze(ctx);
-               auto indicesTensor = args[1].ITensor();
+               auto indicesTensor = args[1].ITensorOrFreeze(ctx);
                // Set datatype for indices tensor to INT32
-               indicesTensor->setType(nvinfer1::DataType::kINT32);
+               auto identity = ctx->net->addIdentity(*indicesTensor);
+               identity->setOutputType(0, nvinfer1::DataType::kINT32);
+               indicesTensor = identity->getOutput(0);
 
                // IGatherLayer takes in input tensor, the indices, and the axis of input tensor to take indices from
                auto gather_layer = ctx->net->addGather(*embeddingTensor, *indicesTensor, 0);

--- a/tests/core/conversion/converters/test_select.cpp
+++ b/tests/core/conversion/converters/test_select.cpp
@@ -106,7 +106,7 @@ TEST(Converters, ATenEmbeddingConvertsCorrectly) {
   auto jit_results = trtorch::tests::util::RunGraph(g, params, {jit_in});
 
   // Run TensorRT
-  auto options_trt = torch::TensorOptions().device(torch::kCUDA, 0).dtype(torch::kI32);
+  auto options_trt = torch::TensorOptions().device(torch::kCUDA, 0).dtype(torch::kFloat);
   auto trt_in = at::tensor({0, 1, 2}, options_trt);
   auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {trt_in});
   auto trt = trt_results[0].reshape(jit_results[0].sizes());


### PR DESCRIPTION
Signed-off-by: Ruoqian Guo <ruoqiang@nvidia.com>

# Description
In my practice, the `indicesTensor ` in aten::embedding sometimes is IValue. So i replaced the ITensor with ITensorOrFreeze.
According to the [document ](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_tensor.html#a1004b03f9249097f6d146abc3772819a), After calling setType, the type of a tensor is unchanged if the tensor is not a network input tensor, or marked as an output tensor or shape output tensor. So i replaced the setType with addIdentity to avoid change the input data type and ensure the indicesTensor is set as INT32.
 
In addition, i use the linters to ensure that my code matches the style guidelines. The linters changed the entire file(core/conversion/converters/impl/select.cpp) . I only modified the aten::embedding part in select.cpp.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes