### PR TITLE
Support feature_dropout and feature_alpha_dropout converters

### DIFF
--- a/core/conversion/conversion_ignorelist.cpp
+++ b/core/conversion/conversion_ignorelist.cpp
@@ -24,7 +24,11 @@ const std::unordered_set<std::string>& get_non_convertable_nodes() {
     "prim::CallMethod",
     "prim::Drop",
     "aten::dropout",
-    "aten::dropout_"};
+    "aten::dropout_",
+    "aten::feature_dropout",
+    "aten::feature_dropout_",
+    "aten::feature_alpha_dropout",
+    "aten::feature_alpha_dropout_"};
   return nonconvertable_nodes;
 }
 // clang-format on

--- a/core/lowering/passes/remove_dropout.cpp
+++ b/core/lowering/passes/remove_dropout.cpp
@@ -32,6 +32,61 @@ void RemoveDropout(std::shared_ptr<torch::jit::Graph>& graph) {
   remove_dropout_inplace_pattern.RegisterRewritePattern(dropout_inplace_pattern, no_dropout_inplace_pattern);
   remove_dropout_inplace_pattern.runOnGraph(graph);
 
+  // remove feature_dropout
+  std::string feature_dropout_pattern = R"IR(
+        graph(%input, %4, %5):
+            %6 = aten::feature_dropout(%input, %4, %5)
+            return (%6))IR";
+  std::string no_feature_dropout_pattern = R"IR(
+        graph(%input, %4, %5):
+            return (%input))IR";
+
+  torch::jit::SubgraphRewriter remove_feature_dropout_pattern;
+  remove_feature_dropout_pattern.RegisterRewritePattern(feature_dropout_pattern, no_feature_dropout_pattern);
+  remove_feature_dropout_pattern.runOnGraph(graph);
+
+  // remove feature_dropout inplace
+  std::string feature_dropout_inplace_pattern = R"IR(
+        graph(%input, %4, %5):
+            %6 = aten::feature_dropout_(%input, %4, %5)
+            return (%6))IR";
+  std::string no_feature_dropout_inplace_pattern = R"IR(
+        graph(%input, %4, %5):
+            return (%input))IR";
+
+  torch::jit::SubgraphRewriter remove_feature_dropout_inplace_pattern;
+  remove_feature_dropout_inplace_pattern.RegisterRewritePattern(
+      feature_dropout_inplace_pattern, no_feature_dropout_inplace_pattern);
+  remove_feature_dropout_inplace_pattern.runOnGraph(graph);
+
+  // remove feature_alpha_dropout
+  std::string feature_alpha_dropout_pattern = R"IR(
+        graph(%input, %4, %5):
+            %6 = aten::feature_alpha_dropout(%input, %4, %5)
+            return (%6))IR";
+  std::string no_feature_alpha_dropout_pattern = R"IR(
+        graph(%input, %4, %5):
+            return (%input))IR";
+
+  torch::jit::SubgraphRewriter remove_feature_alpha_dropout_pattern;
+  remove_feature_alpha_dropout_pattern.RegisterRewritePattern(
+      feature_alpha_dropout_pattern, no_feature_alpha_dropout_pattern);
+  remove_feature_alpha_dropout_pattern.runOnGraph(graph);
+
+  // remove feature_alpha_dropout inplace
+  std::string feature_alpha_dropout_inplace_pattern = R"IR(
+        graph(%input, %4, %5):
+            %6 = aten::feature_alpha_dropout_(%input, %4, %5)
+            return (%6))IR";
+  std::string no_feature_alpha_dropout_inplace_pattern = R"IR(
+        graph(%input, %4, %5):
+            return (%input))IR";
+
+  torch::jit::SubgraphRewriter remove_feature_alpha_dropout_inplace_pattern;
+  remove_feature_alpha_dropout_inplace_pattern.RegisterRewritePattern(
+      feature_alpha_dropout_inplace_pattern, no_feature_alpha_dropout_inplace_pattern);
+  remove_feature_alpha_dropout_inplace_pattern.runOnGraph(graph);
+
   LOG_GRAPH("Post remove dropout: " << *graph);
 }
 

--- a/tests/core/lowering/BUILD
+++ b/tests/core/lowering/BUILD
@@ -16,6 +16,10 @@ lowering_test(
 )
 
 lowering_test(
+  name = "test_remove_dropout_pass",
+)
+
+lowering_test(
   name = "test_remove_to",
 )
 
@@ -38,6 +42,7 @@ test_suite(
         ":test_remove_contiguous_pass",
         ":test_remove_to",
         ":test_remove_detach_pass",
-        ":test_operator_aliasing_pass"
+        ":test_operator_aliasing_pass",
+        ":test_remove_dropout_pass"
     ]
 )

--- a/tests/core/lowering/test_remove_dropout_pass.cpp
+++ b/tests/core/lowering/test_remove_dropout_pass.cpp
@@ -1,0 +1,152 @@
+#include <string>
+#include "core/compiler.h"
+#include "core/lowering/passes/passes.h"
+#include "core/util/prelude.h"
+#include "gtest/gtest.h"
+#include "tests/util/util.h"
+#include "torch/csrc/jit/ir/irparser.h"
+#include "torch/csrc/jit/ir/subgraph_matcher.h"
+
+TEST(LoweringPasses, RemoveDropoutLowersCorrectly) {
+  std::string source_graph = R"IR(
+    graph(%x.1):
+      %3 : float = prim::Constant[value=0.5]()
+      %4 : bool = prim::Constant[value=0]()
+      %y.1 : Tensor = aten::dropout(%x.1, %3, %4)
+      %11 : Tensor = aten::relu(%y.1)
+      return (%11))IR";
+  std::string target_graph = R"IR(
+    graph(%x.1):
+      %11 : Tensor = aten::relu(%x.1)
+      return (%11))IR";
+
+  trtorch::core::util::logging::get_logger().set_reportable_log_level(trtorch::core::util::logging::LogLevel::kGRAPH);
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, sg.get());
+  trtorch::core::lowering::passes::RemoveDropout(sg);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, tg.get());
+
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}
+
+TEST(LoweringPasses, RemoveDropoutInplaceLowersCorrectly) {
+  std::string source_graph = R"IR(
+    graph(%x.1):
+      %3 : float = prim::Constant[value=0.5]()
+      %4 : bool = prim::Constant[value=0]()
+      %y.1 : Tensor = aten::dropout_(%x.1, %3, %4)
+      %11 : Tensor = aten::relu(%y.1)
+      return (%11))IR";
+  std::string target_graph = R"IR(
+    graph(%x.1):
+      %11 : Tensor = aten::relu(%x.1)
+      return (%11))IR";
+
+  trtorch::core::util::logging::get_logger().set_reportable_log_level(trtorch::core::util::logging::LogLevel::kGRAPH);
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, sg.get());
+  trtorch::core::lowering::passes::RemoveDropout(sg);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, tg.get());
+
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}
+
+TEST(LoweringPasses, RemoveFeatureDropoutLowersCorrectly) {
+  std::string source_graph = R"IR(
+    graph(%x.1):
+      %3 : float = prim::Constant[value=0.5]()
+      %4 : bool = prim::Constant[value=0]()
+      %y.1 : Tensor = aten::feature_dropout(%x.1, %3, %4)
+      %11 : Tensor = aten::relu(%y.1)
+      return (%11))IR";
+  std::string target_graph = R"IR(
+    graph(%x.1):
+      %11 : Tensor = aten::relu(%x.1)
+      return (%11))IR";
+
+  trtorch::core::util::logging::get_logger().set_reportable_log_level(trtorch::core::util::logging::LogLevel::kGRAPH);
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, sg.get());
+  trtorch::core::lowering::passes::RemoveDropout(sg);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, tg.get());
+
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}
+
+TEST(LoweringPasses, RemoveFeatureDropoutInplaceLowersCorrectly) {
+  std::string source_graph = R"IR(
+    graph(%x.1):
+      %3 : float = prim::Constant[value=0.5]()
+      %4 : bool = prim::Constant[value=0]()
+      %y.1 : Tensor = aten::feature_dropout_(%x.1, %3, %4)
+      %11 : Tensor = aten::relu(%y.1)
+      return (%11))IR";
+  std::string target_graph = R"IR(
+    graph(%x.1):
+      %11 : Tensor = aten::relu(%x.1)
+      return (%11))IR";
+
+  trtorch::core::util::logging::get_logger().set_reportable_log_level(trtorch::core::util::logging::LogLevel::kGRAPH);
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, sg.get());
+  trtorch::core::lowering::passes::RemoveDropout(sg);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, tg.get());
+
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}
+
+TEST(LoweringPasses, RemoveFeatureAlphaDropoutLowersCorrectly) {
+  std::string source_graph = R"IR(
+    graph(%x.1):
+      %3 : float = prim::Constant[value=0.5]()
+      %4 : bool = prim::Constant[value=0]()
+      %y.1 : Tensor = aten::feature_alpha_dropout(%x.1, %3, %4)
+      %11 : Tensor = aten::relu(%y.1)
+      return (%11))IR";
+  std::string target_graph = R"IR(
+    graph(%x.1):
+      %11 : Tensor = aten::relu(%x.1)
+      return (%11))IR";
+
+  trtorch::core::util::logging::get_logger().set_reportable_log_level(trtorch::core::util::logging::LogLevel::kGRAPH);
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, sg.get());
+  trtorch::core::lowering::passes::RemoveDropout(sg);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, tg.get());
+
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}
+
+TEST(LoweringPasses, RemoveFeatureAlphaDropoutInplaceLowersCorrectly) {
+  std::string source_graph = R"IR(
+    graph(%x.1):
+      %3 : float = prim::Constant[value=0.5]()
+      %4 : bool = prim::Constant[value=0]()
+      %y.1 : Tensor = aten::feature_alpha_dropout_(%x.1, %3, %4)
+      %11 : Tensor = aten::relu(%y.1)
+      return (%11))IR";
+  std::string target_graph = R"IR(
+    graph(%x.1):
+      %11 : Tensor = aten::relu(%x.1)
+      return (%11))IR";
+
+  trtorch::core::util::logging::get_logger().set_reportable_log_level(trtorch::core::util::logging::LogLevel::kGRAPH);
+  auto sg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(source_graph, sg.get());
+  trtorch::core::lowering::passes::RemoveDropout(sg);
+
+  auto tg = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(target_graph, tg.get());
+
+  ASSERT_TRUE(!torch::jit::findPatternMatches(*tg, *sg).empty());
+}


### PR DESCRIPTION
Signed-off-by: Ruoqian Guo <ruoqiang@nvidia.com>

# Description
As described in the [documentation](https://pytorch.org/docs/stable/nn.functional.html?highlight=feature_alpha_dropout#torch.nn.functional.feature_alpha_dropout), aten::feature_dropout and aten::feature_alpha_dropout are similar to aten::dropout that they should be removed from the graph in inference phase.

Fixes #273 

## Type of change

Please delete options that are not relevant and/or add your own.
- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes