### PR TITLE
feat: support prim::Param for fallback inputs

### DIFF
--- a/core/partitioning/partitioning.cpp
+++ b/core/partitioning/partitioning.cpp
@@ -106,7 +106,9 @@ void registerSegmentInOutIValues(
   // set inputs ivalues, now supports Tensor/Int to pass argumentes between different segments
   for (auto& input : seg_block.raw_inputs()) {
     TRTORCH_CHECK(ivalues_maps.count(input), "Could not find mini graph input IValue " << input->debugName());
-    if (input->type()->isSubtypeOf(torch::jit::TensorType::get())) {
+    if (input->node()->kind() == torch::jit::prim::Param) {
+      jit_inputs_ivalues.push_back(ivalues_maps[input]);
+    } else if (input->type()->isSubtypeOf(torch::jit::TensorType::get())) {
       jit_inputs_ivalues.push_back(ivalues_maps[input].toTensor());
     } else if (input->type()->isSubtypeOf(torch::jit::IntType::get())) {
       jit_inputs_ivalues.push_back(ivalues_maps[input].toInt());


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
Support input node kind of prim::Param in registerSegmentInOutIValues. Without this if branch, prim::Param will go to **input->type()->isSubtypeOf(torch::jit::TensorType::get())** this branch and throw **Expected Tensor but got InvalidTag(3409)**

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes