### PR TITLE
fix bug of replication_pad when input is dynamic

### DIFF
--- a/core/conversion/converters/impl/replication_pad.cpp
+++ b/core/conversion/converters/impl/replication_pad.cpp
@@ -67,6 +67,9 @@ bool replication_padXd(ConversionCtx* ctx, const torch::jit::Node* n, args& args
         at::Tensor dimValue = torch::tensor({axis}, torch::kInt32);
         auto dimTensor = tensor_to_const(ctx, dimValue);
         indicesTensor = ctx->net->addGather(*shapeTensor, *dimTensor, 0)->getOutput(0);
+        auto oneTensor = tensor_to_const(ctx, torch::tensor({1}, torch::kInt32));
+        indicesTensor =
+            ctx->net->addElementWise(*indicesTensor, *oneTensor, nvinfer1::ElementWiseOperation::kSUB)->getOutput(0);
       } else {
         auto indices = torch::tensor({inDims.d[axis] - 1}, torch::kInt32);
         indicesTensor = tensor_to_const(ctx, indices);


### PR DESCRIPTION
Signed-off-by: Ruoqian Guo <ruoqiang@nvidia.com>

# Description

When the last dimension of the input is specified as dynamic, the index of the last dimension will be out of range.

Fixes # (issue)

To Reproduce
The bug can be reproduced by change  https://github.com/NVIDIA/TRTorch/blob/3589730201efdef104e1a9d869a43507de865527/tests/util/run_graph_engine.cpp#L44 to 
```
min_range[opt.size() - 1] = ceil(opt[opt.size() - 1] / 2.0);
max_range[opt.size() - 1] = 2 * opt[opt.size() - 1];
```

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes