### PR TITLE
feat(//py): Catch when bazel is not in path and error out when running

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -49,6 +49,7 @@ BAZEL_EXE = which("bazel")
 if BAZEL_EXE is None:
     sys.exit("Could not find bazel in PATH")
 
+
 def build_libtrtorch_pre_cxx11_abi(develop=True, use_dist_dir=True, cxx11_abi=False):
     cmd = [BAZEL_EXE, "build"]
     cmd.append("//cpp/api/lib:libtrtorch.so")

--- a/py/setup.py
+++ b/py/setup.py
@@ -46,6 +46,8 @@ def which(program):
 
 BAZEL_EXE = which("bazel")
 
+if BAZEL_EXE is None:
+    sys.exit("Could not find bazel in PATH")
 
 def build_libtrtorch_pre_cxx11_abi(develop=True, use_dist_dir=True, cxx11_abi=False):
     cmd = [BAZEL_EXE, "build"]


### PR DESCRIPTION
setup.py

# Description

Checks if bazel was found in the path otherwise errors out 

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes