### PR TITLE
gelu layer setName using util::node_info(n).c_str()

### DIFF
--- a/core/conversion/converters/impl/activation.cpp
+++ b/core/conversion/converters/impl/activation.cpp
@@ -161,7 +161,7 @@ auto acthardtanh TRTORCH_UNUSED =
                     TRTORCH_CHECK(new_layer, "Unable to create layer for aten::elu");
                     new_layer->setAlpha(alpha);
 
-                    new_layer->setName(trtorch::core::util::node_info(n).c_str());
+                    new_layer->setName(util::node_info(n).c_str());
 
                     auto out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], new_layer->getOutput(0));
                     LOG_DEBUG("Output shape: " << out_tensor->getDimensions());
@@ -190,7 +190,7 @@ auto acthardtanh TRTORCH_UNUSED =
                     TRTORCH_CHECK(gelu_plugin, "Unable to create gelu plugin from TensorRT plugin registry" << *n);
                     auto new_layer =
                         ctx->net->addPluginV2(reinterpret_cast<nvinfer1::ITensor* const*>(&in), 1, *gelu_plugin);
-                    new_layer->setName("gelu");
+                    new_layer->setName(util::node_info(n).c_str());
                     auto out_tensor = new_layer->getOutput(0);
                     out_tensor = ctx->AssociateValueAndTensor(n->outputs()[0], out_tensor);
                     LOG_DEBUG("Output shape: " << out_tensor->getDimensions());


### PR DESCRIPTION
# Description

Set name of Gelu layer to "util::node_info(n).c_str()"  instead of string "gelu", to prevent "Repeated layer name: gelu (layers must have distinct names)"  error when building tensorrt engine from a module with multiple gelu layers.

Also format "trtorch::core::util::node_info(n).c_str()" to "util::node_info(n).c_str()".

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes