### PR TITLE
feat(//core/plugins): Gating plugin logging based on global config

### DIFF
--- a/core/plugins/register_plugins.cpp
+++ b/core/plugins/register_plugins.cpp
@@ -14,36 +14,37 @@ namespace impl {
 class TRTorchPluginRegistry {
  public:
   TRTorchPluginRegistry() {
-    trtorch_logger.log(util::logging::LogLevel::kINFO, "Instatiated the TRTorch plugin registry class");
     // register libNvInferPlugins and TRTorch plugins
     // trtorch_logger logging level is set to kERROR and reset back to kDEBUG.
     // This is because initLibNvInferPlugins initializes only a subset of plugins and logs them.
     // Plugins outside this subset in TensorRT are not being logged in this. So temporarily we disable this to prevent
     // multiple logging of same plugins. To provide a clear list of all plugins, we iterate through getPluginRegistry()
     // where it prints the list of all the plugins registered in TensorRT with their namespaces.
-    trtorch_logger.set_reportable_log_level(util::logging::LogLevel::kERROR);
-    initLibNvInferPlugins(&trtorch_logger, "");
-    trtorch_logger.set_reportable_log_level(util::logging::LogLevel::kDEBUG);
+    plugin_logger.set_reportable_log_level(util::logging::LogLevel::kERROR);
+    initLibNvInferPlugins(&plugin_logger, "");
+    plugin_logger.set_reportable_log_level(util::logging::get_logger().get_reportable_log_level());
 
     int numCreators = 0;
     auto pluginsList = getPluginRegistry()->getPluginCreatorList(&numCreators);
     for (int k = 0; k < numCreators; ++k) {
       if (!pluginsList[k]) {
-        trtorch_logger.log(util::logging::LogLevel::kDEBUG, "Plugin creator for plugin " + str(k) + " is a nullptr");
+        plugin_logger.log(util::logging::LogLevel::kDEBUG, "Plugin creator for plugin " + str(k) + " is a nullptr");
         continue;
       }
       std::string pluginNamespace = pluginsList[k]->getPluginNamespace();
-      trtorch_logger.log(
+      plugin_logger.log(
           util::logging::LogLevel::kDEBUG,
           "Registered plugin creator - " + std::string(pluginsList[k]->getPluginName()) +
               ", Namespace: " + pluginNamespace);
     }
-    trtorch_logger.log(util::logging::LogLevel::kDEBUG, "Total number of plugins registered: " + str(numCreators));
+    plugin_logger.log(util::logging::LogLevel::kDEBUG, "Total number of plugins registered: " + str(numCreators));
   }
 
  public:
-  util::logging::TRTorchLogger trtorch_logger =
-      util::logging::TRTorchLogger("[TRTorch Plugins Context] - ", util::logging::LogLevel::kDEBUG, true);
+  util::logging::TRTorchLogger plugin_logger = util::logging::TRTorchLogger(
+      "[TRTorch Plugins Context] - ",
+      util::logging::get_logger().get_reportable_log_level(),
+      util::logging::get_logger().get_is_colored_output_on());
 };
 
 namespace {


### PR DESCRIPTION
# Description

Uses global config to set reportable logging level

Superseeds: #458 

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes