### PR TITLE
fix(//core/conversion/conversionctx): Guard final engine building

### DIFF
--- a/core/conversion/conversionctx/ConversionCtx.cpp
+++ b/core/conversion/conversionctx/ConversionCtx.cpp
@@ -23,16 +23,15 @@ std::ostream& operator<<(std::ostream& os, const BuilderSettings& s) {
        << "\n    Max Workspace Size: " << s.workspace_size;
 
     if (s.max_batch_size != 0) {
-        os << "\n    Max Batch Size: " << s.max_batch_size;
+    os << "\n    Max Batch Size: " << s.max_batch_size;
     } else {
-        os << "\n    Max Batch Size: Not set";
+    os << "\n    Max Batch Size: Not set";
     }
 
     os << "\n    Device Type: " << s.device.device_type                                    \
        << "\n    GPU ID: " << s.device.gpu_id;
-    if (s.device.device_type == nvinfer1::DeviceType::kDLA)
-    {
-        os << "\n    DLACore: " << s.device.dla_core;
+    if (s.device.device_type == nvinfer1::DeviceType::kDLA) {
+    os << "\n    DLACore: " << s.device.dla_core;
     }
     os << "\n    Engine Capability: " << s.capability                                      \
        << "\n    Calibrator Created: " << (s.calibrator != nullptr);
@@ -146,6 +145,9 @@ torch::jit::IValue* ConversionCtx::AssociateValueAndIValue(const torch::jit::Val
 
 std::string ConversionCtx::SerializeEngine() {
   auto engine = builder->buildEngineWithConfig(*net, *cfg);
+  if (!engine) {
+    TRTORCH_THROW_ERROR("Building TensorRT engine failed");
+  }
   auto serialized_engine = engine->serialize();
   engine->destroy();
   auto engine_str = std::string((const char*)serialized_engine->data(), serialized_engine->size());

--- a/core/util/Exception.cpp
+++ b/core/util/Exception.cpp
@@ -11,7 +11,7 @@ Error::Error(const std::string& new_msg, const void* caller) : msg_stack_{new_ms
 }
 
 Error::Error(const char* file, const uint32_t line, const std::string& msg, const void* caller)
-    : Error(str("[enforce fail at ", file, ":", line, "] ", msg, "\n"), caller) {}
+    : Error(str("[Error thrown at ", file, ":", line, "] ", msg, "\n"), caller) {}
 
 std::string Error::msg() const {
   return std::accumulate(msg_stack_.begin(), msg_stack_.end(), std::string(""));


### PR DESCRIPTION
# Description

Fixes an issue where if final network validation fails, a segfault
occurs. Now an exception is thrown which can be handled by the user

Fixes #475 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes