### PR TITLE
Handling ITensors in append and also unwrapping ITensors as result of evaluators

### DIFF
--- a/core/conversion/conversion.cpp
+++ b/core/conversion/conversion.cpp
@@ -46,7 +46,7 @@ c10::optional<torch::jit::IValue> EvaluateNode(ConversionCtx* ctx, const torch::
         // WARN: If the converter returns None then should pass through
         // but if repeated dep this section will get called each time
         auto val = result.value();
-        if (val.isCustomClass()){
+        if (val.isCustomClass()) {
           auto cont = val.toCustomClass<TensorContainer>();
           ctx->AssociateValueAndTensor(eval_in, cont->tensor());
           eval_args[eval_in] = ctx->value_tensor_map[eval_in];

--- a/tests/core/conversion/evaluators/test_aten_evaluators.cpp
+++ b/tests/core/conversion/evaluators/test_aten_evaluators.cpp
@@ -236,3 +236,84 @@ TEST(Evaluators, FloorFloatIntEvaluatesCorrectly) {
 
   ASSERT_TRUE(jit_results[0] == trt_results[0]);
 }
+
+TEST(Evaluators, ATenAppendWithITensorEvaluatesCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor, %1 : Tensor):
+        %2 : int = prim::Constant[value=0]()
+        %3 : Tensor[] = prim::ListConstruct(%0)
+        %4 : Tensor[] = aten::append(%3, %1)
+        %5 : Tensor = aten::cat(%4, %2)
+        return (%5))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto in0 = at::randint(1, 10, {3, 3}, {at::kCUDA});
+  auto in1 = at::randint(1, 10, {3, 3}, {at::kCUDA});
+
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {in0, in1});
+
+  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {in0, in1});
+
+  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}
+
+TEST(Evaluators, ATenAppendWithTensorEvaluatesCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %1 : int[] = prim::Constant[value=[3,3]]()
+        %2 : None = prim::Constant() # :0:0
+        %20 : Device = prim::Constant[value="cuda"]()
+        %3 : Tensor = aten::zeros(%1, %2, %2, %20, %2)
+        %4 : Tensor = aten::zeros(%1, %2, %2, %20, %2)
+        %5 : int = prim::Constant[value=0]()
+        %15 : int = prim::Constant[value=1]()
+        %6 : Tensor[] = prim::ListConstruct(%3)
+        %7 : Tensor[] = aten::append(%6, %4)
+        %8 : Tensor = aten::cat(%7, %5)
+        %9 : Tensor = aten::add(%8, %0, %15)
+        return (%9))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto in0 = at::randint(1, 10, {6, 3}, {at::kCUDA});
+
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {in0});
+
+  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {in0});
+
+  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}
+
+TEST(Evaluators, ATenAppendWithITensorAndTensorEvaluatesCorrectly) {
+  const auto graph = R"IR(
+      graph(%0 : Tensor):
+        %1 : int[] = aten::size(%0)
+        %2 : None = prim::Constant() # :0:0
+        %20 : Device = prim::Constant[value="cuda"]()
+        %3 : Tensor = aten::zeros(%1, %2, %2, %20, %2)
+        %4 : int = prim::Constant[value=0]()
+        %5 : Tensor[] = prim::ListConstruct(%0)
+        %6 : Tensor[] = aten::append(%5, %3)
+        %7 : Tensor = aten::cat(%6, %4)
+        return (%7))IR";
+
+  auto g = std::make_shared<torch::jit::Graph>();
+  torch::jit::parseIR(graph, &*g);
+
+  auto in0 = at::randint(1, 10, {3, 3}, {at::kCUDA});
+
+  auto params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto jit_results = trtorch::tests::util::RunGraph(g, params, {in0});
+
+  params = trtorch::core::conversion::get_named_params(g->inputs(), {});
+  auto trt_results = trtorch::tests::util::RunGraphEngine(g, params, {in0});
+
+  ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[0], trt_results[0].reshape_as(jit_results[0]), 2e-6));
+}


### PR DESCRIPTION
# Description

Now we can handle ITensors as inputs to append and handle returning singular ITensors from evaluators 

Fixes #471

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes