### PR TITLE
fix: Transfer calibration data to gpu when the batch is not a list

### DIFF
--- a/py/trtorch/ptq.py
+++ b/py/trtorch/ptq.py
@@ -34,6 +34,8 @@ def get_batch(self, names):
     # Treat the first element as input and others as targets.
     if isinstance(batch, list):
         batch = batch[0].to(self.device)
+    else:
+        batch = batch.to(self.device)
     return [batch.data_ptr()]
 
 


### PR DESCRIPTION
# Description

Transfer calibration data to gpu when the batch is not a list

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes