### PR TITLE
feat(serde)!: Refactor CudaDevice struct, implement ABI versioning, serde cleanup

### DIFF
--- a/core/runtime/BUILD
+++ b/core/runtime/BUILD
@@ -10,8 +10,11 @@ config_setting(
 cc_library(
     name = "runtime",
     srcs = [
+        "CudaDevice.cpp",
+        "DeviceList.cpp",
         "TRTEngine.cpp",
         "register_trt_op.cpp",
+        "runtime.cpp"
     ],
     hdrs = [
         "runtime.h",

--- a/core/runtime/CudaDevice.cpp
+++ b/core/runtime/CudaDevice.cpp
@@ -34,9 +34,6 @@ CudaDevice::CudaDevice(int64_t gpu_id, nvinfer1::DeviceType device_type) {
   // Set Device name
   this->device_name = device_name;
 
-  // Set Device name len for serialization/deserialization
-  this->device_name_len = device_name.size();
-
   // Set Device Type
   this->device_type = device_type;
 }
@@ -70,14 +67,20 @@ CudaDevice::CudaDevice(std::string device_info) {
 }
 
 std::string CudaDevice::serialize() {
+  std::vector<std::string> content;
+  content.resize(DEVICE_NAME_IDX + 1);
+
+  content[ID_IDX] = std::to_string(id);
+  content[SM_MAJOR_IDX] = std::to_string(major);
+  content[SM_MINOR_IDX] = std::to_string(minor);
+  content[DEVICE_TYPE_IDX] = std::to_string((int64_t)device_type);
+  content[DEVICE_NAME_IDX] = device_name;
+
   std::stringstream ss;
-  // clang-format off
-  ss << id << DEVICE_INFO_DELIM \
-     << major << DEVICE_INFO_DELIM \
-     << minor << DEVICE_INFO_DELIM \
-     << (int64_t) device_type << DEVICE_INFO_DELIM
-     << device_name;
-  // clang-format on
+  for (size_t i = 0; i < content.size() - 1; i++) {
+    ss << content[i] << DEVICE_INFO_DELIM;
+  }
+  ss << content[DEVICE_NAME_IDX];
 
   std::string serialized_device_info = ss.str();
 

--- a/core/runtime/CudaDevice.cpp
+++ b/core/runtime/CudaDevice.cpp
@@ -1,0 +1,103 @@
+#include "cuda_runtime.h"
+
+#include "core/runtime/runtime.h"
+#include "core/util/prelude.h"
+
+namespace trtorch {
+namespace core {
+namespace runtime {
+
+const std::string DEVICE_INFO_DELIM = "%";
+
+typedef enum { ID_IDX = 0, SM_MAJOR_IDX, SM_MINOR_IDX, DEVICE_TYPE_IDX, DEVICE_NAME_IDX } SerializedDeviceInfoIndex;
+
+CudaDevice::CudaDevice() : id{-1}, major{-1}, minor{-1}, device_type{nvinfer1::DeviceType::kGPU} {}
+
+CudaDevice::CudaDevice(int64_t gpu_id, nvinfer1::DeviceType device_type) {
+  CudaDevice cuda_device;
+  cudaDeviceProp device_prop;
+
+  // Device ID
+  this->id = gpu_id;
+
+  // Get Device Properties
+  cudaGetDeviceProperties(&device_prop, gpu_id);
+
+  // Compute capability major version
+  this->major = device_prop.major;
+
+  // Compute capability minor version
+  this->minor = device_prop.minor;
+
+  std::string device_name(device_prop.name);
+
+  // Set Device name
+  this->device_name = device_name;
+
+  // Set Device name len for serialization/deserialization
+  this->device_name_len = device_name.size();
+
+  // Set Device Type
+  this->device_type = device_type;
+}
+
+// NOTE: Serialization Format for Device Info:
+// id%major%minor%(enum)device_type%device_name
+
+CudaDevice::CudaDevice(std::string device_info) {
+  LOG_DEBUG("Deserializing Device Info: " << device_info);
+
+  std::vector<std::string> tokens;
+  int64_t start = 0;
+  int64_t end = device_info.find(DEVICE_INFO_DELIM);
+
+  while (end != -1) {
+    tokens.push_back(device_info.substr(start, end - start));
+    start = end + DEVICE_INFO_DELIM.size();
+    end = device_info.find(DEVICE_INFO_DELIM, start);
+  }
+  tokens.push_back(device_info.substr(start, end - start));
+
+  TRTORCH_CHECK(tokens.size() == DEVICE_NAME_IDX + 1, "Unable to deserializable program target device infomation");
+
+  id = std::stoi(tokens[ID_IDX]);
+  major = std::stoi(tokens[SM_MAJOR_IDX]);
+  minor = std::stoi(tokens[SM_MINOR_IDX]);
+  device_type = (nvinfer1::DeviceType)(std::stoi(tokens[DEVICE_TYPE_IDX]));
+  device_name = tokens[DEVICE_NAME_IDX];
+
+  LOG_DEBUG("Deserialized Device Info: " << *this);
+}
+
+std::string CudaDevice::serialize() {
+  std::stringstream ss;
+  // clang-format off
+  ss << id << DEVICE_INFO_DELIM \
+     << major << DEVICE_INFO_DELIM \
+     << minor << DEVICE_INFO_DELIM \
+     << (int64_t) device_type << DEVICE_INFO_DELIM
+     << device_name;
+  // clang-format on
+
+  std::string serialized_device_info = ss.str();
+
+  LOG_DEBUG("Serialized Device Info: " << serialized_device_info);
+
+  return serialized_device_info;
+}
+
+std::string CudaDevice::getSMCapability() const {
+  std::stringstream ss;
+  ss << major << "." << minor;
+  return ss.str();
+}
+
+std::ostream& operator<<(std::ostream& os, const CudaDevice& device) {
+  os << "Device(ID: " << device.id << ", Name: " << device.device_name << ", SM Capability: " << device.major << '.'
+     << device.minor << ", Type: " << device.device_type << ')';
+  return os;
+}
+
+} // namespace runtime
+} // namespace core
+} // namespace trtorch

--- a/core/runtime/DeviceList.cpp
+++ b/core/runtime/DeviceList.cpp
@@ -1,0 +1,45 @@
+#include "cuda_runtime.h"
+
+#include "core/runtime/runtime.h"
+#include "core/util/prelude.h"
+
+namespace trtorch {
+namespace core {
+namespace runtime {
+
+DeviceList::DeviceList() {
+  int num_devices = 0;
+  auto status = cudaGetDeviceCount(&num_devices);
+  TRTORCH_ASSERT((status == cudaSuccess), "Unable to read CUDA capable devices. Return status: " << status);
+  for (int i = 0; i < num_devices; i++) {
+    device_list[i] = CudaDevice(i, nvinfer1::DeviceType::kGPU);
+  }
+
+  // REVIEW: DO WE CARE ABOUT DLA?
+
+  LOG_DEBUG("Runtime:\n Available CUDA Devices: \n" << this->dump_list());
+}
+
+void DeviceList::insert(int device_id, CudaDevice cuda_device) {
+  device_list[device_id] = cuda_device;
+}
+
+CudaDevice DeviceList::find(int device_id) {
+  return device_list[device_id];
+}
+
+DeviceList::DeviceMap DeviceList::get_devices() {
+  return device_list;
+}
+
+std::string DeviceList::dump_list() {
+  std::stringstream ss;
+  for (auto it = device_list.begin(); it != device_list.end(); ++it) {
+    ss << "    " << it->second << std::endl;
+  }
+  return ss.str();
+}
+
+} // namespace runtime
+} // namespace core
+} // namespace trtorch

--- a/core/runtime/TRTEngine.cpp
+++ b/core/runtime/TRTEngine.cpp
@@ -11,6 +11,8 @@ namespace trtorch {
 namespace core {
 namespace runtime {
 
+typedef enum { ABI_TARGET_IDX = 0, DEVICE_IDX, ENGINE_IDX } SerializedInfoIndex;
+
 std::string slugify(std::string s) {
   std::replace(s.begin(), s.end(), '.', '_');
   return s;
@@ -30,6 +32,12 @@ TRTEngine::TRTEngine(std::vector<std::string> serialized_info)
           std::string("[] = "),
           util::logging::get_logger().get_reportable_severity(),
           util::logging::get_logger().get_is_colored_output_on()) {
+  TRTORCH_CHECK(
+      serialized_info.size() == ENGINE_IDX + 1, "Program to be deserialized targets an incompatible TRTorch ABI");
+  TRTORCH_CHECK(
+      serialized_info[ABI_TARGET_IDX] == ABI_VERSION,
+      "Program to be deserialized targets a different TRTorch ABI Version ("
+          << serialized_info[ABI_TARGET_IDX] << ") than the TRTorch Runtime ABI (" << ABI_VERSION << ")");
   std::string _name = "deserialized_trt";
   std::string engine_info = serialized_info[ENGINE_IDX];
 
@@ -116,6 +124,7 @@ static auto TRTORCH_UNUSED TRTEngineTSRegistrtion =
               auto trt_engine = std::string((const char*)serialized_trt_engine->data(), serialized_trt_engine->size());
 
               std::vector<std::string> serialize_info;
+              serialize_info.push_back(ABI_VERSION);
               serialize_info.push_back(serialize_device(self->device_info));
               serialize_info.push_back(trt_engine);
               return serialize_info;
@@ -124,123 +133,6 @@ static auto TRTORCH_UNUSED TRTEngineTSRegistrtion =
               return c10::make_intrusive<TRTEngine>(std::move(seralized_info));
             });
 } // namespace
-void set_cuda_device(CudaDevice& cuda_device) {
-  TRTORCH_CHECK((cudaSetDevice(cuda_device.id) == cudaSuccess), "Unable to set device: " << cuda_device.id);
-}
-
-void get_cuda_device(CudaDevice& cuda_device) {
-  int device = 0;
-  TRTORCH_CHECK(
-      (cudaGetDevice(reinterpret_cast<int*>(&device)) == cudaSuccess),
-      "Unable to get current device: " << cuda_device.id);
-  cuda_device.id = static_cast<int64_t>(device);
-  cudaDeviceProp device_prop;
-  TRTORCH_CHECK(
-      (cudaGetDeviceProperties(&device_prop, cuda_device.id) == cudaSuccess),
-      "Unable to get CUDA properties from device:" << cuda_device.id);
-  cuda_device.set_major(device_prop.major);
-  cuda_device.set_minor(device_prop.minor);
-  std::string device_name(device_prop.name);
-  cuda_device.set_device_name(device_name);
-}
-
-std::string serialize_device(CudaDevice& cuda_device) {
-  void* buffer = new char[sizeof(cuda_device)];
-  void* ref_buf = buffer;
-
-  int64_t temp = cuda_device.get_id();
-  memcpy(buffer, reinterpret_cast<int64_t*>(&temp), sizeof(int64_t));
-  buffer = static_cast<char*>(buffer) + sizeof(int64_t);
-
-  temp = cuda_device.get_major();
-  memcpy(buffer, reinterpret_cast<int64_t*>(&temp), sizeof(int64_t));
-  buffer = static_cast<char*>(buffer) + sizeof(int64_t);
-
-  temp = cuda_device.get_minor();
-  memcpy(buffer, reinterpret_cast<int64_t*>(&temp), sizeof(int64_t));
-  buffer = static_cast<char*>(buffer) + sizeof(int64_t);
-
-  auto device_type = cuda_device.get_device_type();
-  memcpy(buffer, reinterpret_cast<char*>(&device_type), sizeof(nvinfer1::DeviceType));
-  buffer = static_cast<char*>(buffer) + sizeof(nvinfer1::DeviceType);
-
-  size_t device_name_len = cuda_device.get_device_name_len();
-  memcpy(buffer, reinterpret_cast<char*>(&device_name_len), sizeof(size_t));
-  buffer = static_cast<char*>(buffer) + sizeof(size_t);
-
-  auto device_name = cuda_device.get_device_name();
-  memcpy(buffer, reinterpret_cast<char*>(&device_name), device_name.size());
-  buffer = static_cast<char*>(buffer) + device_name.size();
-
-  return std::string((const char*)ref_buf, sizeof(int64_t) * 3 + sizeof(nvinfer1::DeviceType) + device_name.size());
-}
-
-CudaDevice deserialize_device(std::string device_info) {
-  CudaDevice ret;
-  char* buffer = new char[device_info.size() + 1];
-  std::copy(device_info.begin(), device_info.end(), buffer);
-  int64_t temp = 0;
-
-  memcpy(&temp, reinterpret_cast<char*>(buffer), sizeof(int64_t));
-  buffer += sizeof(int64_t);
-  ret.set_id(temp);
-
-  memcpy(&temp, reinterpret_cast<char*>(buffer), sizeof(int64_t));
-  buffer += sizeof(int64_t);
-  ret.set_major(temp);
-
-  memcpy(&temp, reinterpret_cast<char*>(buffer), sizeof(int64_t));
-  buffer += sizeof(int64_t);
-  ret.set_minor(temp);
-
-  nvinfer1::DeviceType device_type;
-  memcpy(&device_type, reinterpret_cast<char*>(buffer), sizeof(nvinfer1::DeviceType));
-  buffer += sizeof(nvinfer1::DeviceType);
-
-  size_t size;
-  memcpy(&size, reinterpret_cast<size_t*>(&buffer), sizeof(size_t));
-  buffer += sizeof(size_t);
-
-  ret.set_device_name_len(size);
-
-  std::string device_name;
-  memcpy(&device_name, reinterpret_cast<char*>(buffer), size * sizeof(char));
-  buffer += size * sizeof(char);
-
-  ret.set_device_name(device_name);
-
-  return ret;
-}
-
-CudaDevice get_device_info(int64_t gpu_id, nvinfer1::DeviceType device_type) {
-  CudaDevice cuda_device;
-  cudaDeviceProp device_prop;
-
-  // Device ID
-  cuda_device.set_id(gpu_id);
-
-  // Get Device Properties
-  cudaGetDeviceProperties(&device_prop, gpu_id);
-
-  // Compute capability major version
-  cuda_device.set_major(device_prop.major);
-
-  // Compute capability minor version
-  cuda_device.set_minor(device_prop.minor);
-
-  std::string device_name(device_prop.name);
-
-  // Set Device name
-  cuda_device.set_device_name(device_name);
-
-  // Set Device name len for serialization/deserialization
-  cuda_device.set_device_name_len(device_name.size());
-
-  // Set Device Type
-  cuda_device.set_device_type(device_type);
-
-  return cuda_device;
-}
 
 } // namespace runtime
 } // namespace core

--- a/core/runtime/register_trt_op.cpp
+++ b/core/runtime/register_trt_op.cpp
@@ -27,18 +27,17 @@ bool is_switch_required(const CudaDevice& curr_device, const CudaDevice& conf_de
     if (curr_device.device_name != conf_device.device_name) {
       LOG_WARNING(
           "Program compiled for " << conf_device.device_name << " but current CUDA device is " << curr_device
-                                  << ". Switching the device context");
+                                  << ". Attempting to switch device context for better compatibility");
       return true;
     }
   }
 
-  // REVIEW: This shouldnt be a reason to switch GPU
-  // if (curr_device.id != conf_device.id) {
-  //   LOG_WARNING(
-  //       "Configured Device ID: " << conf_device.id << " is different that current device ID: " << curr_device.id
-  //                                << ". Switching context");
-  //   return true;
-  // }
+  if (curr_device.id != conf_device.id) {
+    LOG_WARNING(
+        "Configured Device ID: " << conf_device.id << " is different that current device ID: " << curr_device.id
+                                 << ". Moving input tensors to device: " << conf_device.id);
+    return true;
+  }
 
   return false;
 }

--- a/core/runtime/register_trt_op.cpp
+++ b/core/runtime/register_trt_op.cpp
@@ -10,18 +10,15 @@ namespace trtorch {
 namespace core {
 namespace runtime {
 
-// SM Compute capability <Compute Capability, Device Name> map
-const std::unordered_map<std::string, std::string>& get_dla_supported_SM() {
-  // Xavier SM Compute Capability
-  static std::unordered_map<std::string, std::string> dla_supported_SM = {{"7.2", "Xavier"}};
-  return dla_supported_SM;
-}
-
 // Checks if the context switch requred for device ID
 bool is_switch_required(const CudaDevice& curr_device, const CudaDevice& conf_device) {
   // If SM capability is not the same as configured then switch
   if ((curr_device.major != conf_device.major) || (curr_device.minor != conf_device.minor)) {
-    LOG_WARNING("Configured SM capability does not match with current device ID. Switching context");
+    LOG_WARNING(
+        "Configured SM capability " << conf_device.getSMCapability()
+                                    << " does not match with current device SM capability "
+                                    << curr_device.getSMCapability() << " (" << curr_device
+                                    << "). Switching device context");
     return true;
   }
 
@@ -29,61 +26,72 @@ bool is_switch_required(const CudaDevice& curr_device, const CudaDevice& conf_de
   if (conf_device.device_type == nvinfer1::DeviceType::kGPU) {
     if (curr_device.device_name != conf_device.device_name) {
       LOG_WARNING(
-          "TRTEngine compiled for " << conf_device.device_name << " but current CUDA device is "
-                                    << curr_device.device_name << ". Switching the device context");
+          "Program compiled for " << conf_device.device_name << " but current CUDA device is " << curr_device
+                                  << ". Switching the device context");
       return true;
     }
   }
 
-  if (curr_device.id != conf_device.id) {
-    LOG_WARNING(
-        "Configured Device ID: " << conf_device.id << " is different that current device ID: " << curr_device.id
-                                 << ". Switching context");
-    return true;
-  }
+  // REVIEW: This shouldnt be a reason to switch GPU
+  // if (curr_device.id != conf_device.id) {
+  //   LOG_WARNING(
+  //       "Configured Device ID: " << conf_device.id << " is different that current device ID: " << curr_device.id
+  //                                << ". Switching context");
+  //   return true;
+  // }
 
   return false;
 }
 
-int select_cuda_device(const CudaDevice& conf_device) {
-  int device_id = 0;
-  auto dla_supported = get_dla_supported_SM();
+CudaDevice select_cuda_device(const CudaDevice& conf_device) {
+  int64_t device_id = -1;
+  auto dla_supported = get_dla_supported_SMs();
 
-  auto device_list = cuda_device_list.instance().get_devices();
+  auto device_list = get_available_device_list().get_devices();
+
+  CudaDevice new_target_device;
 
   for (auto device : device_list) {
-    auto compute_cap = std::to_string(device.second.major) + "." + std::to_string(device.second.minor);
+    auto compute_cap = device.second.getSMCapability();
     // In case of DLA select the DLA supported device ID
     if (conf_device.device_type == nvinfer1::DeviceType::kDLA) {
       if (dla_supported.find(compute_cap) != dla_supported.end() &&
           dla_supported[compute_cap] == device.second.device_name) {
         device_id = device.second.id;
+        new_target_device = CudaDevice(device_id, nvinfer1::DeviceType::kDLA);
         break;
       }
     } else if (conf_device.device_type == nvinfer1::DeviceType::kGPU) {
-      auto conf_sm = std::to_string(conf_device.major) + "." + std::to_string(conf_device.minor);
+      auto conf_sm = conf_device.getSMCapability();
       if (compute_cap == conf_sm && device.second.device_name == conf_device.device_name) {
         device_id = device.second.id;
+        new_target_device = CudaDevice(device_id, nvinfer1::DeviceType::kGPU);
         break;
       }
     } else {
-      LOG_ERROR("Unkown device type detected from the compiled engine");
+      TRTORCH_THROW_ERROR("Unknown target device type detected from the compiled program (runtime.select_cuda_device)");
       break;
     }
   }
-  return device_id;
+
+  // REVIEW: THIS DOES NOT LIST DLA PROBABLY, WHICH WE SHOULD
+  TRTORCH_CHECK(
+      device_id >= 0,
+      "No compatible device found on system to run program.\n Program targets "
+          << conf_device << "\n Available targets: \n"
+          << get_available_device_list().dump_list() << "\n(runtime.select_cuda_device)");
+  return new_target_device;
 }
 
 std::vector<at::Tensor> execute_engine(std::vector<at::Tensor> inputs, c10::intrusive_ptr<TRTEngine> compiled_engine) {
   LOG_DEBUG("Attempting to run engine (ID: " << compiled_engine->name << ")");
 
-  CudaDevice curr_device;
-  get_cuda_device(curr_device);
-  LOG_DEBUG("Current Device ID: " << curr_device.id);
+  CudaDevice curr_device = get_current_device();
+  LOG_DEBUG("Current Device: " << curr_device);
 
   if (is_switch_required(curr_device, compiled_engine->device_info)) {
     // Scan through available CUDA devices and set the CUDA device context correctly
-    CudaDevice device{.id = select_cuda_device(compiled_engine->device_info)};
+    CudaDevice device = select_cuda_device(compiled_engine->device_info);
     set_cuda_device(device);
 
     std::string target_device = "cuda:" + std::to_string(device.id);

--- a/core/runtime/runtime.cpp
+++ b/core/runtime/runtime.cpp
@@ -13,7 +13,7 @@ void set_cuda_device(CudaDevice& cuda_device) {
 }
 
 CudaDevice get_current_device() {
-  int device = 0;
+  int device = -1;
   TRTORCH_CHECK(
       (cudaGetDevice(reinterpret_cast<int*>(&device)) == cudaSuccess),
       "Unable to get current device (runtime.get_current_device)");

--- a/core/runtime/runtime.cpp
+++ b/core/runtime/runtime.cpp
@@ -1,0 +1,51 @@
+#include "cuda_runtime.h"
+
+#include "core/runtime/runtime.h"
+#include "core/util/prelude.h"
+
+namespace trtorch {
+namespace core {
+namespace runtime {
+
+void set_cuda_device(CudaDevice& cuda_device) {
+  TRTORCH_CHECK(
+      (cudaSetDevice(cuda_device.id) == cudaSuccess), "Unable to set device: " << cuda_device << "as active device");
+}
+
+CudaDevice get_current_device() {
+  int device = 0;
+  TRTORCH_CHECK(
+      (cudaGetDevice(reinterpret_cast<int*>(&device)) == cudaSuccess),
+      "Unable to get current device (runtime.get_current_device)");
+
+  int64_t device_id = static_cast<int64_t>(device);
+
+  return CudaDevice(device_id, nvinfer1::DeviceType::kGPU);
+}
+
+std::string serialize_device(CudaDevice& cuda_device) {
+  return cuda_device.serialize();
+}
+
+CudaDevice deserialize_device(std::string device_info) {
+  return CudaDevice(device_info);
+}
+
+namespace {
+static DeviceList cuda_device_list;
+}
+
+DeviceList get_available_device_list() {
+  return cuda_device_list;
+}
+
+// SM Compute capability <Compute Capability, Device Name> map
+const std::unordered_map<std::string, std::string>& get_dla_supported_SMs() {
+  // Xavier SM Compute Capability
+  static std::unordered_map<std::string, std::string> dla_supported_SM = {{"7.2", "Xavier"}};
+  return dla_supported_SM;
+}
+
+} // namespace runtime
+} // namespace core
+} // namespace trtorch

--- a/core/runtime/runtime.h
+++ b/core/runtime/runtime.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <map>
 #include <utility>
 #include "ATen/core/function_schema.h"
 #include "NvInfer.h"
@@ -10,8 +11,7 @@ namespace core {
 namespace runtime {
 
 using EngineID = int64_t;
-
-typedef enum { DEVICE_IDX = 0, ENGINE_IDX } SerializedInfoIndex;
+const std::string ABI_VERSION = "2";
 
 struct CudaDevice {
   int64_t id; // CUDA device id
@@ -21,62 +21,20 @@ struct CudaDevice {
   size_t device_name_len;
   std::string device_name;
 
-  int64_t get_id(void) {
-    return this->id;
-  }
-
-  void set_id(int64_t gpu_id) {
-    this->id = gpu_id;
-  }
-
-  int64_t get_major(void) {
-    return major;
-  }
-
-  void set_major(int64_t major_version) {
-    this->major = major_version;
-  }
-
-  int64_t get_minor(void) {
-    return minor;
-  }
-
-  void set_minor(int64_t minor_version) {
-    this->minor = minor_version;
-  }
-
-  nvinfer1::DeviceType get_device_type(void) {
-    return device_type;
-  }
-
-  void set_device_type(nvinfer1::DeviceType dev_type = nvinfer1::DeviceType::kGPU) {
-    this->device_type = dev_type;
-  }
-
-  std::string get_device_name(void) {
-    return device_name;
-  }
-
-  void set_device_name(std::string& name) {
-    this->device_name = name;
-  }
-
-  size_t get_device_name_len(void) {
-    return device_name_len;
-  }
-
-  void set_device_name_len(size_t size) {
-    this->device_name_len = size;
-  }
+  CudaDevice();
+  CudaDevice(int64_t gpu_id, nvinfer1::DeviceType device_type);
+  CudaDevice(std::string serialized_device_info);
+  std::string serialize();
+  std::string getSMCapability() const;
+  friend std::ostream& operator<<(std::ostream& os, const CudaDevice& device);
 };
 
 void set_cuda_device(CudaDevice& cuda_device);
-void get_cuda_device(CudaDevice& cuda_device);
+// Gets the current active GPU (DLA will not show up through this)
+CudaDevice get_current_device();
 
 std::string serialize_device(CudaDevice& cuda_device);
 CudaDevice deserialize_device(std::string device_info);
-
-CudaDevice get_device_info(int64_t gpu_id, nvinfer1::DeviceType device_type);
 
 struct TRTEngine : torch::CustomClassHolder {
   // Each engine needs it's own runtime object
@@ -109,42 +67,17 @@ class DeviceList {
 
  public:
   // Scans and updates the list of available CUDA devices
-  DeviceList(void) {
-    int num_devices = 0;
-    auto status = cudaGetDeviceCount(&num_devices);
-    TRTORCH_ASSERT((status == cudaSuccess), "Unable to read CUDA capable devices. Return status: " << status);
-    cudaDeviceProp device_prop;
-    for (int i = 0; i < num_devices; i++) {
-      TRTORCH_CHECK(
-          (cudaGetDeviceProperties(&device_prop, i) == cudaSuccess),
-          "Unable to read CUDA Device Properies for device id: " << i);
-      std::string device_name(device_prop.name);
-      CudaDevice device = {
-          i, device_prop.major, device_prop.minor, nvinfer1::DeviceType::kGPU, device_name.size(), device_name};
-      device_list[i] = device;
-    }
-  }
+  DeviceList();
 
  public:
-  static DeviceList& instance() {
-    static DeviceList obj;
-    return obj;
-  }
-
-  void insert(int device_id, CudaDevice cuda_device) {
-    device_list[device_id] = cuda_device;
-  }
-  CudaDevice find(int device_id) {
-    return device_list[device_id];
-  }
-  DeviceMap get_devices() {
-    return device_list;
-  }
+  void insert(int device_id, CudaDevice cuda_device);
+  CudaDevice find(int device_id);
+  DeviceMap get_devices();
+  std::string dump_list();
 };
 
-namespace {
-static DeviceList cuda_device_list;
-}
+DeviceList get_available_device_list();
+const std::unordered_map<std::string, std::string>& get_dla_supported_SMs();
 
 } // namespace runtime
 } // namespace core

--- a/core/runtime/runtime.h
+++ b/core/runtime/runtime.h
@@ -18,7 +18,6 @@ struct CudaDevice {
   int64_t major; // CUDA compute major version
   int64_t minor; // CUDA compute minor version
   nvinfer1::DeviceType device_type;
-  size_t device_name_len;
   std::string device_name;
 
   CudaDevice();

--- a/cpp/api/src/compile_spec.cpp
+++ b/cpp/api/src/compile_spec.cpp
@@ -84,7 +84,7 @@ core::runtime::CudaDevice to_internal_cuda_device(CompileSpec::Device device) {
     default:
       device_type = nvinfer1::DeviceType::kGPU;
   }
-  return core::runtime::get_device_info(device.gpu_id, device_type);
+  return core::runtime::CudaDevice(device.gpu_id, device_type);
 }
 
 core::CompileSpec to_internal_compile_spec(CompileSpec external) {

--- a/py/trtorch/csrc/tensorrt_backend.cpp
+++ b/py/trtorch/csrc/tensorrt_backend.cpp
@@ -54,7 +54,7 @@ c10::impl::GenericDict TensorRTBackend::compile(c10::IValue mod_val, c10::impl::
     auto named_params = core::conversion::get_named_params(g->inputs(), params);
 
     auto device_spec = convert_cfg.engine_settings.device;
-    auto device = core::runtime::get_device_info(device_spec.gpu_id, device_spec.device_type);
+    auto device = core::runtime::CudaDevice(device_spec.gpu_id, device_spec.device_type);
     auto serialized_engine = core::conversion::ConvertBlockToEngine(g->block(), convert_cfg, named_params);
     auto engine_handle = c10::make_intrusive<core::runtime::TRTEngine>(it->key(), serialized_engine, device);
     handles.insert(method.name(), at::IValue(engine_handle));

--- a/tests/util/run_graph_engine.cpp
+++ b/tests/util/run_graph_engine.cpp
@@ -54,7 +54,7 @@ std::vector<core::ir::InputRange> toInputRangesDynamic(std::vector<at::Tensor> t
 
 std::vector<at::Tensor> RunEngine(std::string& eng, std::vector<at::Tensor> inputs) {
   LOG_DEBUG("Running TRT version");
-  auto cuda_device = core::runtime::get_device_info(0, nvinfer1::DeviceType::kGPU);
+  auto cuda_device = core::runtime::CudaDevice(0, nvinfer1::DeviceType::kGPU);
   auto engine_ptr = c10::make_intrusive<trtorch::core::runtime::TRTEngine>("test_engine", eng, cuda_device);
   auto outputs = trtorch::core::runtime::execute_engine(inputs, engine_ptr);
   return outputs;


### PR DESCRIPTION
# Description

BREAKING CHANGE: This commit cleans up the WIP CudaDevice class,
simplifying implementation and formalizing the seralized format for CUDA
devices.

It also implements ABI Versioning. The first entry in the serialized
format of a TRTEngine now records the ABI that the engine was compiled
with, defining expected compatibility with the TRTorch runtime. If the
ABI version does not match, the runtime will error out asking to
recompile the program.

ABI version is a monotonically increasing integer and should be
incremented everytime the serialization format changes in some way.

This commit cleans up the CudaDevice class, implementing a number of
constructors to replace the various utility functions that populate the
struct. Descriptive utility functions remain but solely call the
relevant constructor.
Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes