### PR TITLE
string(char) operator+()  mistake.

### DIFF
--- a/core/conversion/converters/converter_util.cpp
+++ b/core/conversion/converters/converter_util.cpp
@@ -53,7 +53,7 @@ nvinfer1::ITensor* addUnpadding(
     TRTORCH_CHECK(shuffle_layer, "Unable to create shuffle layer");
     shuffle_layer->setReshapeDimensions(newDims);
     shuffle_layer->setZeroIsPlaceholder(use_zeros);
-    shuffle_layer->setName((util::node_info(n) + " [Reshape to " + util::toStr(newDims)).c_str() + ']');
+    shuffle_layer->setName((util::node_info(n) + " [Reshape to " + util::toStr(newDims) + "]").c_str());
     return shuffle_layer->getOutput(0);
   } else {
     return tensor;


### PR DESCRIPTION
# Description
Set layer name with wrong string.
`+ ']'` will call char pointer operation, not string append. 
This could result in `ERROR: [TRTorch Conversion Context] - Repeated layer name` during compiling.


## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes