### PR TITLE
Fixed string corruption on setName() in addUnpadding

### DIFF
--- a/core/conversion/converters/converter_util.cpp
+++ b/core/conversion/converters/converter_util.cpp
@@ -53,7 +53,7 @@ nvinfer1::ITensor* addUnpadding(
     TRTORCH_CHECK(shuffle_layer, "Unable to create shuffle layer");
     shuffle_layer->setReshapeDimensions(newDims);
     shuffle_layer->setZeroIsPlaceholder(use_zeros);
-    shuffle_layer->setName((util::node_info(n) + " [Reshape to " + util::toStr(newDims) + "]").c_str());
+    shuffle_layer->setName((util::node_info(n) + " [Reshape from " + util::toStr(dims) + "]").c_str());
     return shuffle_layer->getOutput(0);
   } else {
     return tensor;


### PR DESCRIPTION
Signed-off-by: Boris Fomitchev <bfomitchev@nvidia.com>

This string lifetime issue manifested itself in corrupted (truncated beginning) string sent to setName() which would result in duplicate layer names later.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes