### PR TITLE
fix(runtime): Fix document generator failure for non-GPU host machines

### DIFF
--- a/core/runtime/DeviceList.cpp
+++ b/core/runtime/DeviceList.cpp
@@ -10,7 +10,10 @@ namespace runtime {
 DeviceList::DeviceList() {
   int num_devices = 0;
   auto status = cudaGetDeviceCount(&num_devices);
-  TRTORCH_ASSERT((status == cudaSuccess), "Unable to read CUDA capable devices. Return status: " << status);
+  if (status != cudaSuccess) {
+    LOG_WARNING("Unable to read CUDA capable devices. Return status: " << status);
+  }
+
   for (int i = 0; i < num_devices; i++) {
     device_list[i] = CudaDevice(i, nvinfer1::DeviceType::kGPU);
   }


### PR DESCRIPTION
Signed-off-by: Anurag Dixit <anuragd@nvidia.com>

# Description

Changed assert to warning logs. Document generation is not applicable to host machines with GPU cards. Hence, failure to read any CUDA-capable device is not a valid use case scenario. 

Fixes # (issue)

Bug fix (non-breaking change)


# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes