### PR TITLE
fix(trtorchc): Allow for workspaces larger than 2G and better debugging

### DIFF
--- a/cpp/trtorchc/main.cpp
+++ b/cpp/trtorchc/main.cpp
@@ -60,9 +60,9 @@ trtorch::CompileSpec::TensorFormat parseTensorFormat(std::string str) {
 trtorch::CompileSpec::DataType parseDataType(std::string dtype_str) {
   std::transform(
       dtype_str.begin(), dtype_str.end(), dtype_str.begin(), [](unsigned char c) { return std::tolower(c); });
-  if (dtype_str == "float" || dtype_str == "float32" || dtype_str == "f32") {
+  if (dtype_str == "float" || dtype_str == "float32" || dtype_str == "f32" || dtype_str == "fp32") {
     return trtorch::CompileSpec::DataType::kFloat;
-  } else if (dtype_str == "half" || dtype_str == "float16" || dtype_str == "f16") {
+  } else if (dtype_str == "half" || dtype_str == "float16" || dtype_str == "f16" || dtype_str == "fp16") {
     return trtorch::CompileSpec::DataType::kHalf;
   } else if (dtype_str == "char" || dtype_str == "int8" || dtype_str == "i8") {
     return trtorch::CompileSpec::DataType::kChar;
@@ -73,7 +73,7 @@ trtorch::CompileSpec::DataType parseDataType(std::string dtype_str) {
   } else {
     trtorch::logging::log(
         trtorch::logging::Level::kERROR,
-        "Invalid precision, options are [ float | float32 | f32 | half | float16 | f16 | char | int8 | i8 | int | int32 | i32 | bool | b], found: " + dtype_str);
+        "Invalid precision, options are [ float | float32 | fp32 | f32 | half | float16 | fp16 | f16 | char | int8 | i8 | int | int32 | i32 | bool | b], found: " + dtype_str);
     return trtorch::CompileSpec::DataType::kUnknown;
   }
 }
@@ -214,7 +214,7 @@ int main(int argc, char** argv) {
   args::ValueFlagList<std::string> enabled_precision(
       parser,
       "precision",
-      "(Repeatable) Enabling an operating precision for kernels to use when building the engine (Int8 requires a calibration-cache argument) [ float | float32 | f32 | half | float16 | f16 | int8 | i8 ] (default: float)",
+      "(Repeatable) Enabling an operating precision for kernels to use when building the engine (Int8 requires a calibration-cache argument) [ float | float32 | f32 | fp32 | half | float16 | f16 | fp16 | int8 | i8 | char ] (default: float)",
       {'p', "enabled-precison"});
   args::ValueFlag<std::string> device_type(
       parser,
@@ -434,7 +434,7 @@ int main(int argc, char** argv) {
         }
       } else {
         std::stringstream ss;
-        ss << "Invalid precision, options are [ float | float32 | f32 | half | float16 | f16 | char | int8 | i8 ], found: ";
+        ss << "Invalid precision given for enabled kernel precision, options are [ float | float32 | f32 | fp32 | half | float16 | f16 | fp16 | char | int8 | i8 ], found: ";
         ss << dtype;
         trtorch::logging::log(
             trtorch::logging::Level::kERROR, ss.str());

--- a/cpp/trtorchc/main.cpp
+++ b/cpp/trtorchc/main.cpp
@@ -52,7 +52,8 @@ trtorch::CompileSpec::TensorFormat parseTensorFormat(std::string str) {
   } else {
     trtorch::logging::log(
         trtorch::logging::Level::kERROR,
-        "Invalid tensor format, options are [ linear | nchw | chw | contiguous | nhwc | hwc | channels_last ], found: " + str);
+        "Invalid tensor format, options are [ linear | nchw | chw | contiguous | nhwc | hwc | channels_last ], found: " +
+            str);
     return trtorch::CompileSpec::TensorFormat::kUnknown;
   }
 }
@@ -73,7 +74,8 @@ trtorch::CompileSpec::DataType parseDataType(std::string dtype_str) {
   } else {
     trtorch::logging::log(
         trtorch::logging::Level::kERROR,
-        "Invalid precision, options are [ float | float32 | fp32 | f32 | half | float16 | fp16 | f16 | char | int8 | i8 | int | int32 | i32 | bool | b], found: " + dtype_str);
+        "Invalid precision, options are [ float | float32 | fp32 | f32 | half | float16 | fp16 | f16 | char | int8 | i8 | int | int32 | i32 | bool | b], found: " +
+            dtype_str);
     return trtorch::CompileSpec::DataType::kUnknown;
   }
 }
@@ -221,7 +223,8 @@ int main(int argc, char** argv) {
       "type",
       "The type of device the engine should be built for [ gpu | dla ] (default: gpu)",
       {'d', "device-type"});
-  args::ValueFlag<uint64_t> gpu_id(parser, "gpu_id", "GPU id if running on multi-GPU platform (defaults to 0)", {"gpu-id"});
+  args::ValueFlag<uint64_t> gpu_id(
+      parser, "gpu_id", "GPU id if running on multi-GPU platform (defaults to 0)", {"gpu-id"});
   args::ValueFlag<uint64_t> dla_core(
       parser, "dla_core", "DLACore id if running on available DLA (defaults to 0)", {"dla-core"});
 
@@ -436,8 +439,7 @@ int main(int argc, char** argv) {
         std::stringstream ss;
         ss << "Invalid precision given for enabled kernel precision, options are [ float | float32 | f32 | fp32 | half | float16 | f16 | fp16 | char | int8 | i8 ], found: ";
         ss << dtype;
-        trtorch::logging::log(
-            trtorch::logging::Level::kERROR, ss.str());
+        trtorch::logging::log(trtorch::logging::Level::kERROR, ss.str());
         std::cerr << std::endl << parser;
         return 1;
       }
@@ -461,7 +463,8 @@ int main(int argc, char** argv) {
         compile_settings.device.dla_core = args::get(dla_core);
       }
     } else {
-      trtorch::logging::log(trtorch::logging::Level::kERROR, "Invalid device type, options are [ gpu | dla ] found: " + device);
+      trtorch::logging::log(
+          trtorch::logging::Level::kERROR, "Invalid device type, options are [ gpu | dla ] found: " + device);
       std::cerr << std::endl << parser;
       return 1;
     }


### PR DESCRIPTION
# Description

Allows trtorchc to accept workspace sizes larger than 2GB and prints out better errors if string parsing fails. 

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project (You can use the linters)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas and hacks
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests to verify my fix or my feature
- [ ] New and existing unit tests pass locally with my changes