### PR TITLE
fix(device_conf): Devices never actually got swithed in multi device

### DIFF
--- a/core/runtime/CudaDevice.cpp
+++ b/core/runtime/CudaDevice.cpp
@@ -66,6 +66,15 @@ CudaDevice::CudaDevice(std::string device_info) {
   LOG_DEBUG("Deserialized Device Info: " << *this);
 }
 
+CudaDevice& CudaDevice::operator=(const CudaDevice& other) {
+  id = other.id;
+  major = other.major;
+  minor = other.minor;
+  device_type = other.device_type;
+  device_name = other.device_name;
+  return (*this);
+}
+
 std::string CudaDevice::serialize() {
   std::vector<std::string> content;
   content.resize(DEVICE_NAME_IDX + 1);

--- a/core/runtime/TRTEngine.cpp
+++ b/core/runtime/TRTEngine.cpp
@@ -38,7 +38,9 @@ TRTEngine::TRTEngine(std::vector<std::string> serialized_info) {
 }
 
 TRTEngine::TRTEngine(std::string mod_name, std::string serialized_engine, CudaDevice cuda_device) {
-  device_info = cuda_device;
+  auto most_compatible_device = get_most_compatible_device(cuda_device);
+  TRTORCH_CHECK(most_compatible_device, "No compatible device was found for instantiating TensorRT engine");
+  device_info = most_compatible_device.value();
   set_cuda_device(device_info);
 
   rt = std::shared_ptr<nvinfer1::IRuntime>(nvinfer1::createInferRuntime(util::logging::get_logger()));

--- a/core/runtime/runtime.cpp
+++ b/core/runtime/runtime.cpp
@@ -7,9 +7,72 @@ namespace trtorch {
 namespace core {
 namespace runtime {
 
+c10::optional<CudaDevice> get_most_compatible_device(const CudaDevice& target_device) {
+  LOG_DEBUG("Target Device: " << target_device);
+  auto device_options = find_compatible_devices(target_device);
+  if (device_options.size() == 0) {
+    return {};
+  } else if (device_options.size() == 1) {
+    return {device_options[0]};
+  }
+
+  CudaDevice best_match;
+  std::stringstream dev_list;
+  dev_list << "[" << std::endl;
+  for (auto device : device_options) {
+    dev_list << "    " << device << ',' << std::endl;
+    if (device.device_name == target_device.device_name && best_match.device_name != target_device.device_name) {
+      best_match = device;
+    } else if (device.device_name == target_device.device_name && best_match.device_name == target_device.device_name) {
+      if (device.id == target_device.id && best_match.id != target_device.id) {
+        best_match = device;
+      }
+    }
+  }
+  dev_list << ']';
+  LOG_DEBUG("Compatible device options: " << dev_list.str());
+
+  if (best_match.id == -1) {
+    LOG_DEBUG("No valid device options");
+    return {};
+  } else {
+    LOG_DEBUG("Selected: " << best_match);
+    return {best_match};
+  }
+}
+
+std::vector<CudaDevice> find_compatible_devices(const CudaDevice& target_device) {
+  auto dla_supported = get_dla_supported_SMs();
+  auto device_list = get_available_device_list().get_devices();
+
+  std::vector<CudaDevice> compatible_devices;
+
+  for (auto device : device_list) {
+    auto poss_dev_cc = device.second.getSMCapability();
+    if (target_device.device_type == nvinfer1::DeviceType::kDLA) {
+      if (dla_supported.find(poss_dev_cc) != dla_supported.end() &&
+          dla_supported[poss_dev_cc] == target_device.device_name) {
+        compatible_devices.push_back(device.second);
+      }
+    } else if (target_device.device_type == nvinfer1::DeviceType::kGPU) {
+      auto target_dev_cc = target_device.getSMCapability();
+      // If the SM Capabilities match, should be good enough to run
+      if (poss_dev_cc == target_dev_cc) {
+        compatible_devices.push_back(device.second);
+      }
+    } else {
+      TRTORCH_THROW_ERROR(
+          "Unknown target device type detected from the compiled program (runtime.find_compatible_devices)");
+      break;
+    }
+  }
+  return compatible_devices;
+}
+
 void set_cuda_device(CudaDevice& cuda_device) {
   TRTORCH_CHECK(
       (cudaSetDevice(cuda_device.id) == cudaSuccess), "Unable to set device: " << cuda_device << "as active device");
+  LOG_DEBUG("Setting " << cuda_device << " as active device");
 }
 
 CudaDevice get_current_device() {

--- a/core/runtime/runtime.h
+++ b/core/runtime/runtime.h
@@ -24,6 +24,7 @@ struct CudaDevice {
   CudaDevice();
   CudaDevice(int64_t gpu_id, nvinfer1::DeviceType device_type);
   CudaDevice(std::string serialized_device_info);
+  CudaDevice& operator=(const CudaDevice& other);
   std::string serialize();
   std::string getSMCapability() const;
   friend std::ostream& operator<<(std::ostream& os, const CudaDevice& device);
@@ -32,6 +33,9 @@ struct CudaDevice {
 void set_cuda_device(CudaDevice& cuda_device);
 // Gets the current active GPU (DLA will not show up through this)
 CudaDevice get_current_device();
+
+c10::optional<CudaDevice> get_most_compatible_device(const CudaDevice& target_device);
+std::vector<CudaDevice> find_compatible_devices(const CudaDevice& target_device);
 
 std::string serialize_device(CudaDevice& cuda_device);
 CudaDevice deserialize_device(std::string device_info);

--- a/tests/core/conversion/evaluators/test_aten_evaluators.cpp
+++ b/tests/core/conversion/evaluators/test_aten_evaluators.cpp
@@ -3,6 +3,7 @@
 #include "gtest/gtest.h"
 #include "tests/util/util.h"
 #include "torch/csrc/jit/ir/irparser.h"
+#include "torch/torch.h"
 
 TEST(Evaluators, DivIntEvaluatesCorrectly) {
   const auto graph = R"IR(

--- a/tests/cpp/BUILD
+++ b/tests/cpp/BUILD
@@ -94,10 +94,10 @@ cc_test(
     name = "test_multi_gpu_serdes",
     srcs = ["test_multi_gpu_serdes.cpp"],
     data = [
-        ":jit_models",
+        "//tests/modules:jit_models",
     ],
     deps = [
-        ":module_test",
+        ":cpp_api_test",
     ],
 )
 

--- a/tests/cpp/test_multi_gpu_serdes.cpp
+++ b/tests/cpp/test_multi_gpu_serdes.cpp
@@ -23,11 +23,12 @@ TEST_P(CppAPITests, CompiledModuleIsClose) {
   trt_results.push_back(trt_results_ivalues.toTensor());
 
   for (size_t i = 0; i < trt_results.size(); i++) {
-    ASSERT_TRUE(trtorch::tests::util::almostEqual(jit_results[i], trt_results[i].reshape_as(jit_results[i]), 2e-5));
+    ASSERT_TRUE(trtorch::tests::util::almostEqual(
+        jit_results[i], trt_results[i].reshape_as(jit_results[i]).to(torch::Device("cuda:0")), 2e-5));
   }
 }
 
 INSTANTIATE_TEST_SUITE_P(
     CompiledModuleForwardIsCloseSuite,
     CppAPITests,
-    testing::Values(PathAndInSize({"tests/modules/resnet18_traced.jit.pt", {{1, 3, 224, 224}}})));
+    testing::Values(PathAndInSize({"tests/modules/resnet18_traced.jit.pt", {{1, 3, 224, 224}}, 2e-5})));


### PR DESCRIPTION
cases

# Description

The runtime device switching doesnt actual change the device. Also we just take whatever device is listed and set it to that which is useless in portable cases. Therefore now we have some way to search through devices and find the best match

Fixes # (issue)

## Type of change

Please delete options that are not relevant and/or add your own.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes