### PR TITLE
refactor!: Removing deprecated InputRange, op_precision and input_shapes

### DIFF
--- a/cpp/include/trtorch/trtorch.h
+++ b/cpp/include/trtorch/trtorch.h
@@ -507,64 +507,6 @@ struct TRTORCH_API CompileSpec {
   };
 
   /**
-   * @brief A struct to hold an input range (used by TensorRT Optimization
-   * profile)
-   *
-   * This struct can either hold a single vector representing an input shape,
-   * signifying a static input shape or a set of three input shapes representing
-   * the min, optiminal and max input shapes allowed for the engine.
-   */
-  struct TRTORCH_API InputRange {
-    /// Minimum acceptable input size into the engine
-    std::vector<int64_t> min;
-    /// Optimal input size into the engine (gets best performace)
-    std::vector<int64_t> opt;
-    /// Maximum acceptable input size into the engine
-    std::vector<int64_t> max;
-    /**
-     * @brief Construct a new Input Range object for static input size from
-     * vector
-     *
-     * @param opt
-     */
-    [[deprecated("trtorch::CompileSpec::InputRange is being deprecated in favor of trtorch::CompileSpec::Input. trtorch::CompileSpec::InputRange will be removed in TRTorch v0.5.0")]] InputRange(
-        std::vector<int64_t> opt);
-    /**
-     * @brief Construct a new Input Range object static input size from
-     * c10::ArrayRef (the type produced by tensor.sizes())
-     *
-     * @param opt
-     */
-    [[deprecated("trtorch::CompileSpec::InputRange is being deprecated in favor of trtorch::CompileSpec::Input. trtorch::CompileSpec::InputRange will be removed in TRTorch v0.5.0")]] InputRange(
-        c10::ArrayRef<int64_t> opt);
-    /**
-     * @brief Construct a new Input Range object dynamic input size from vectors
-     * for min, opt, and max supported sizes
-     *
-     * @param min
-     * @param opt
-     * @param max
-     */
-    [[deprecated("trtorch::CompileSpec::InputRange is being deprecated in favor of trtorch::CompileSpec::Input. trtorch::CompileSpec::InputRange will be removed in TRTorch v0.5.0")]] InputRange(
-        std::vector<int64_t> min,
-        std::vector<int64_t> opt,
-        std::vector<int64_t> max);
-    /**
-     * @brief Construct a new Input Range object dynamic input size from
-     * c10::ArrayRef (the type produced by tensor.sizes()) for min, opt, and max
-     * supported sizes
-     *
-     * @param min
-     * @param opt
-     * @param max
-     */
-    [[deprecated("trtorch::CompileSpec::InputRange is being deprecated in favor of trtorch::CompileSpec::Input. trtorch::CompileSpec::InputRange will be removed in TRTorch v0.5.0")]] InputRange(
-        c10::ArrayRef<int64_t> min,
-        c10::ArrayRef<int64_t> opt,
-        c10::ArrayRef<int64_t> max);
-  };
-
-  /**
    * @brief A struct to hold fallback info
    */
   struct TRTORCH_API TorchFallback {
@@ -596,18 +538,6 @@ struct TRTORCH_API CompileSpec {
     TorchFallback(bool enabled, uint64_t min_size) : enabled(enabled), min_block_size(min_size) {}
   };
 
-  /**
-   * @brief Construct a new Extra Info object from input ranges.
-   * Each entry in the vector represents a input and should be provided in call
-   * order.
-   *
-   * Use this constructor if you want to use dynamic shape
-   *
-   * @param input_ranges
-   */
-  [[deprecated("trtorch::CompileSpec::CompileSpec(std::vector<InputRange> input_ranges) is being deprecated in favor of trtorch::CompileSpec::CompileSpec(std::vector<Input> inputs). Please use CompileSpec(std::vector<Input> inputs). trtorch::CompileSpec::CompileSpec(std::vector<InputRange> input_ranges) will be removed in TRTorch v0.5.0")]] CompileSpec(
-      std::vector<InputRange> input_ranges)
-      : input_ranges(std::move(input_ranges)) {}
   /**
    * @brief Construct a new Extra Info object
    * Convienence constructor to set fixed input size from vectors describing
@@ -656,24 +586,6 @@ struct TRTORCH_API CompileSpec {
    * Order in vector should match call order for the function
    */
   std::vector<Input> inputs;
-
-  /**
-   * Sizes for inputs to engine, can either be a single size or a range
-   * defined by Min, Optimal, Max sizes
-   *
-   * Order is should match call order
-   */
-  [[deprecated(
-      "trtorch::CompileSpec::input_ranges is being deprecated in favor of trtorch::CompileSpec::inputs. trtorch::CompileSpec::input_ranges will be removed in TRTorch v0.5.0")]] std::
-      vector<InputRange>
-          input_ranges;
-
-  /**
-   * Default operating precision for the engine
-   */
-  [[deprecated(
-      "trtorch::CompileSpec::op_precision is being deprecated in favor of trtorch::CompileSpec::enabled_precisions, a set of all enabled precisions to use during compilation, trtorch::CompileSpec::op_precision will be removed in TRTorch v0.5.0")]] DataType
-      op_precision = DataType::kFloat;
 
   /**
    * @brief The set of precisions TensorRT is allowed to use for kernels during compilation

--- a/examples/int8/training/vgg16/test_qat.py
+++ b/examples/int8/training/vgg16/test_qat.py
@@ -81,7 +81,7 @@ print("[JIT] Test Loss: {:.5f} Test Acc: {:.2f}%".format(test_loss, 100 * test_a
 import trtorch
 # trtorch.logging.set_reportable_log_level(trtorch.logging.Level.Debug)
 compile_settings = {
-"input_shapes": [[1, 3, 32, 32]],
+"inputs": [trtorch.Input([1, 3, 32, 32])],
 "op_precision": torch.int8 # Run with FP16
 }
 new_mod = torch.jit.load('trained_vgg16_qat.jit.pt')

--- a/py/trtorch/_compile_spec.py
+++ b/py/trtorch/_compile_spec.py
@@ -157,21 +157,10 @@ def _parse_torch_fallback(fallback_info: Dict[str, Any]) -> trtorch._C.TorchFall
 
 def _parse_compile_spec(compile_spec: Dict[str, Any]) -> trtorch._C.CompileSpec:
     info = trtorch._C.CompileSpec()
-    if "input_shapes" not in compile_spec and "inputs" not in compile_spec:
+    if "inputs" not in compile_spec:
         raise KeyError(
             "Module input definitions are requried to compile module. Provide a list of trtorch.Input keyed to \"inputs\" in the compile spec"
         )
-
-    if "input_shapes" in compile_spec and "inputs" in compile_spec:
-        raise KeyError(
-            "Found both key \"input_shapes\", and \"inputs\" in compile spec, please port forward to using only \"inputs\""
-        )
-
-    if "input_shapes" in compile_spec:
-        warnings.warn(
-            "Key \"input_shapes\" is deprecated in favor of \"inputs\". Support for \"input_shapes\" will be removed in TRTorch v0.5.0",
-            DeprecationWarning)
-        info.inputs = _parse_input_ranges(compile_spec["input_shapes"])
 
     if "inputs" in compile_spec:
         info.inputs = [i._to_internal() for i in compile_spec["inputs"]]
@@ -180,12 +169,6 @@ def _parse_compile_spec(compile_spec: Dict[str, Any]) -> trtorch._C.CompileSpec:
         raise KeyError(
             "Found both key \"op_precision\", and \"enabled_precisions\" in compile spec, please port forward to using only \"enabled_precisions\""
         )
-
-    if "op_precision" in compile_spec:
-        warnings.warn(
-            "Key \"op_precision\" is being deprecated in favor of \"enabled_precision\" which expects a set of precisions to be enabled during compilation (FP32 will always be enabled), Support for \"op_precision\" will be removed in TRTorch v0.5.0",
-            DeprecationWarning)
-        info.enabled_precisions = _parse_enabled_precisions(compile_spec["op_precision"])
 
     if "enabled_precisions" in compile_spec:
         info.enabled_precisions = _parse_enabled_precisions(compile_spec["enabled_precisions"])

--- a/tests/py/test_api.py
+++ b/tests/py/test_api.py
@@ -13,38 +13,6 @@ class TestCompile(ModelTestCase):
         self.traced_model = torch.jit.trace(self.model, [self.input])
         self.scripted_model = torch.jit.script(self.model)
 
-    def test_compile_traced_deprecated(self):
-        compile_spec = {
-            "input_shapes": [self.input.shape],
-            "device": {
-                "device_type": trtorch.DeviceType.GPU,
-                "gpu_id": 0,
-                "dla_core": 0,
-                "allow_gpu_fallback": False,
-                "disable_tf32": False
-            }
-        }
-
-        trt_mod = trtorch.compile(self.traced_model, compile_spec)
-        same = (trt_mod(self.input) - self.traced_model(self.input)).abs().max()
-        self.assertTrue(same < 2e-3)
-
-    def test_compile_script_deprecated(self):
-        compile_spec = {
-            "input_shapes": [self.input.shape],
-            "device": {
-                "device_type": trtorch.DeviceType.GPU,
-                "gpu_id": 0,
-                "dla_core": 0,
-                "allow_gpu_fallback": False,
-                "disable_tf32": False
-            }
-        }
-
-        trt_mod = trtorch.compile(self.scripted_model, compile_spec)
-        same = (trt_mod(self.input) - self.scripted_model(self.input)).abs().max()
-        self.assertTrue(same < 2e-3)
-
     def test_compile_traced(self):
         compile_spec = {
             "inputs": [trtorch.Input(self.input.shape, dtype=torch.float, format=torch.contiguous_format)],

--- a/tests/py/test_qat_trt_accuracy.py
+++ b/tests/py/test_qat_trt_accuracy.py
@@ -55,7 +55,7 @@ class TestAccuracy(ModelTestCase):
 
         compile_spec = {
             "inputs": [trtorch.Input([16, 3, 32, 32])],
-            "op_precision": torch.int8,
+            "enabled_precisions": {torch.int8},
             # "enabled_precision": {torch.float32, torch.int8},
         }
 


### PR DESCRIPTION
APIs

# Description
BREAKING CHANGE: This removes the InputRange Class and op_precision and
input shape fields which were deprecated in TRTorch v0.4.0

## Type of change

Please delete options that are not relevant and/or add your own.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes