### PR TITLE
chore: Bumping default dep version on x86 for PyTorch to 1.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ torch.jit.save(trt_ts_module, "trt_torchscript_module.ts")
 These are the following dependencies used to verify the testcases. TRTorch can work with other versions, but the tests are not guaranteed to pass.
 
 - Bazel 4.0.0
-- Libtorch 1.9.0 (built with CUDA 11.1)
+- Libtorch 1.9.1 (built with CUDA 11.1)
 - CUDA 11.1 (10.2 on Jetson)
 - cuDNN 8.2
 - TensorRT 8.0.1.6

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,17 +50,17 @@ new_local_repository(
 http_archive(
     name = "libtorch",
     build_file = "@//third_party/libtorch:BUILD",
-    sha256 = "edc12091193ba772db77a6ec14e05cef6da881288fca0dfc89a031f631601f60",
+    sha256 = "db57b1023fb33768286a98ba22c44cfe03d6ed158bc2dc0ca1d4928ee5f19f60",
     strip_prefix = "libtorch",
-    urls = ["https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip"],
+    urls = ["https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.1%2Bcu111.zip"],
 )
 
 http_archive(
     name = "libtorch_pre_cxx11_abi",
     build_file = "@//third_party/libtorch:BUILD",
-    sha256 = "af9435fa4b44bb395c1a7645391c00228a72af4305f43a61e9300c0abdbe0819",
+    sha256 = "5563ca53b2b5342f1ab7eef9baf308f197673663ad5b1458a031c46dd802f413",
     strip_prefix = "libtorch",
-    urls = ["https://download.pytorch.org/libtorch/cu111/libtorch-shared-with-deps-1.9.0%2Bcu111.zip"],
+    urls = ["https://download.pytorch.org/libtorch/cu111/libtorch-shared-with-deps-1.9.1%2Bcu111.zip"],
 )
 
 # Download these tarballs manually from the NVIDIA website

--- a/docker/WORKSPACE.docs
+++ b/docker/WORKSPACE.docs
@@ -52,17 +52,17 @@ new_local_repository(
 http_archive(
     name = "libtorch",
     build_file = "@//third_party/libtorch:BUILD",
-    sha256 = "edc12091193ba772db77a6ec14e05cef6da881288fca0dfc89a031f631601f60",
+    sha256 = "db57b1023fb33768286a98ba22c44cfe03d6ed158bc2dc0ca1d4928ee5f19f60",
     strip_prefix = "libtorch",
-    urls = ["https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.0%2Bcu111.zip"],
+    urls = ["https://download.pytorch.org/libtorch/cu111/libtorch-cxx11-abi-shared-with-deps-1.9.1%2Bcu111.zip"],
 )
 
 http_archive(
     name = "libtorch_pre_cxx11_abi",
     build_file = "@//third_party/libtorch:BUILD",
-    sha256 = "af9435fa4b44bb395c1a7645391c00228a72af4305f43a61e9300c0abdbe0819",
+    sha256 = "5563ca53b2b5342f1ab7eef9baf308f197673663ad5b1458a031c46dd802f413",
     strip_prefix = "libtorch",
-    urls = ["https://download.pytorch.org/libtorch/cu111/libtorch-shared-with-deps-1.9.0%2Bcu111.zip"],
+    urls = ["https://download.pytorch.org/libtorch/cu111/libtorch-shared-with-deps-1.9.1%2Bcu111.zip"],
 )
 
 ####################################################################################

--- a/docsrc/tutorials/installation.rst
+++ b/docsrc/tutorials/installation.rst
@@ -66,7 +66,7 @@ the CUDA driver installed and the container must have CUDA)
 
 The correct LibTorch version will be pulled down for you by bazel.
 
-    NOTE: For best compatability with official PyTorch, use torch==1.9.0+cuda111, TensorRT 7.2 and cuDNN 8.1 for CUDA 11.1 however TRTorch itself supports
+    NOTE: For best compatability with official PyTorch, use torch==1.9.1+cuda111, TensorRT 8.0 and cuDNN 8.2 for CUDA 11.1 however TRTorch itself supports
     TensorRT and cuDNN for CUDA versions other than 11.1 for usecases such as using NVIDIA compiled distributions of PyTorch that use other versions of CUDA
     e.g. aarch64 or custom compiled version of PyTorch.
 
@@ -327,7 +327,7 @@ use that library, set the paths to the same path but when you compile make sure 
 Compile C++ Library and Compiler CLI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    NOTE: Due to shifting dependency locations between Jetpack 4.5 and 4.6 there is a now a flag to inform bazel of the Jetpack version 
+    NOTE: Due to shifting dependency locations between Jetpack 4.5 and 4.6 there is a now a flag to inform bazel of the Jetpack version
 
     .. code-block:: shell
 

--- a/examples/int8/training/vgg16/requirements.txt
+++ b/examples/int8/training/vgg16/requirements.txt
@@ -1,3 +1,3 @@
-torch>=1.9.0
+torch>=1.9.1
 tensorboard>=1.14.0
 pytorch-quantization --extra-index-url https://pypi.ngc.nvidia.com

--- a/examples/trtorchrt_example/README.md
+++ b/examples/trtorchrt_example/README.md
@@ -23,7 +23,7 @@ The main goal is to use TRTorch runtime library `libtrtorchrt.so`, a lightweight
 cd examples/trtorchrt_example/deps
 // Download latest TRTorch release tar file (libtrtorch.tar.gz) from https://github.com/NVIDIA/TRTorch/releases
 tar -xvzf libtrtorch.tar.gz
-unzip libtorch-cxx11-abi-shared-with-deps-1.9.0+cu111.zip
+unzip libtorch-cxx11-abi-shared-with-deps-[PYTORCH_VERSION].zip
 ```
 
 > If cuDNN and TensorRT are not installed on your system / in your LD_LIBRARY_PATH then do the following as well

--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,3 +1,3 @@
 -f https://download.pytorch.org/whl/torch_stable.html
-torch==1.9.0+cu111
+torch==1.9.1+cu111
 pybind11==2.6.2

--- a/tests/modules/requirements.txt
+++ b/tests/modules/requirements.txt
@@ -1,3 +1,3 @@
 -f https://download.pytorch.org/whl/torch_stable.html
 timm==v0.4.12
-torch==1.9.0+cu111
+torch==1.9.1+cu111

--- a/tests/py/requirements.txt
+++ b/tests/py/requirements.txt
@@ -1,2 +1,2 @@
-torchvision==0.10.0+cu111
+torchvision==0.10.1+cu111
 -f https://download.pytorch.org/whl/torch_stable.html


### PR DESCRIPTION
# Description

Bumps dependency for PyTorch to 1.9.1

## Type of change

Please delete options that are not relevant and/or add your own.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project (You can use the linters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas and hacks
- [x] I have made corresponding changes to the documentation
- [x] I have added tests to verify my fix or my feature
- [x] New and existing unit tests pass locally with my changes